### PR TITLE
docs: update sub-agent and command counts in .claude/ documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,11 +87,12 @@ command --flags
 
 ---
 
-## Slash Commands (17 automated workflows)
+## Slash Commands (20 automated workflows)
 
 ### Quick List
 
 **Analysis**: `/optimize-portfolio`, `/compare-periods`, `/tax-report`, `/validate-data`, `/rebalance-portfolio`
+**Investment**: `/investment-strategy`, `/analyze-symbol`, `/options-strategy`
 **Portfolio**: `/dividend-analysis`, `/sector-analysis`, `/wash-sale-check`, `/fx-exposure`
 **Development**: `/test`, `/quality-check`, `/add-test`, `/benchmark`
 **Utility**: `/mcp-status`, `/debug-api`, `/resolve-gh-issue`, `/fetch-latest`
@@ -313,7 +314,7 @@ pytest --cov=ib_sec_mcp
 
 ## Resources
 
-- **.claude/README.md**: Complete feature list (8 sub-agents, 12 commands)
+- **.claude/README.md**: Complete feature list (11 sub-agents, 20 commands)
 - **.claude/SUB_AGENTS.md**: Detailed sub-agent development guide
 - **.claude/SLASH_COMMANDS.md**: Detailed slash command development guide
 - **/CLAUDE.md**: General project development guide

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -49,7 +49,7 @@ This directory powers **Mode 3** of IB Analytics: **Development Automation** wit
 │   ├── market-analyst.md
 │   ├── strategy-coordinator.md
 │   └── portfolio-risk-analyst.md  # NEW: Portfolio risk analysis
-└── commands/              # Custom slash commands (17 commands)
+└── commands/              # Custom slash commands (20 commands)
     ├── fetch-latest.md
     ├── debug-api.md
     ├── test.md
@@ -66,14 +66,17 @@ This directory powers **Mode 3** of IB Analytics: **Development Automation** wit
     ├── dividend-analysis.md   # Dividend income & IE ETF tax efficiency
     ├── sector-analysis.md     # Sector allocation & HHI concentration
     ├── wash-sale-check.md     # Wash sale detection & tax loss harvesting
-    └── fx-exposure.md         # Currency exposure & FX risk simulation
+    ├── fx-exposure.md         # Currency exposure & FX risk simulation
+    ├── analyze-symbol.md      # Comprehensive symbol analysis
+    ├── investment-strategy.md # Investment strategy planning
+    └── options-strategy.md    # Options strategy analysis
 ```
 
 ## 🤖 Sub-Agents (Specialized AI Experts)
 
 Specialized AI assistants that handle specific tasks in their own context window, keeping the main conversation focused.
 
-### Available Sub-Agents (10 Total)
+### Available Sub-Agents (11 Total)
 
 #### 📊 **Investment Analysis Agents** (NEW!)
 

--- a/.claude/SLASH_COMMANDS.md
+++ b/.claude/SLASH_COMMANDS.md
@@ -2,7 +2,7 @@
 
 Detailed guide for creating reusable workflow templates in Claude Code.
 
-## Current Slash Commands (16)
+## Current Slash Commands (20)
 
 **Analysis Commands**:
 
@@ -10,6 +10,13 @@ Detailed guide for creating reusable workflow templates in Claude Code.
 - `/compare-periods` - Period-over-period comparison
 - `/tax-report` - Tax planning report generation
 - `/validate-data` - Data integrity validation
+- `/rebalance-portfolio` - Portfolio rebalancing with target profiles
+
+**Investment Commands**:
+
+- `/investment-strategy` - Comprehensive investment strategy planning
+- `/analyze-symbol` - Symbol analysis (stocks, ETFs, crypto, forex)
+- `/options-strategy` - Options strategy analysis with Greeks and IV
 
 **Portfolio Commands**:
 


### PR DESCRIPTION
## Summary

- Updated stale sub-agent and slash command counts across `.claude/CLAUDE.md`, `.claude/README.md`, and `.claude/SLASH_COMMANDS.md`
- Added missing `/investment-strategy`, `/analyze-symbol`, `/options-strategy` to Quick Lists and directory trees
- Added `/rebalance-portfolio` to SLASH_COMMANDS.md list

## Changes

| File | What Changed |
|------|-------------|
| `.claude/CLAUDE.md` | Commands: 17→20, added Investment category, Resources: (8,12)→(11,20) |
| `.claude/README.md` | Agents: 10→11, Commands: 17→20, added 3 files to directory tree |
| `.claude/SLASH_COMMANDS.md` | Commands: 16→20, added Investment Commands category |

## Verification

- All counts match actual files on disk (11 agents, 20 commands)
- All three files are internally consistent
- No remaining stale references (`grep` confirms zero matches)
- Markdown syntax validated

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)