### PR TITLE
test: add MCP server startup smoke test (#52)

### DIFF
--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -4,6 +4,7 @@ Verifies that the server starts correctly and all expected tools and resources a
 """
 
 import asyncio
+from typing import Any
 
 import pytest
 from fastmcp import FastMCP
@@ -21,8 +22,8 @@ from ib_sec_mcp.mcp.resources import (
 )
 from ib_sec_mcp.mcp.server import create_server
 
-# All 45 expected tool names
-EXPECTED_TOOLS = [
+# All expected tool names
+EXPECTED_TOOLS = {
     # ib_portfolio
     "fetch_ib_data",
     "analyze_performance",
@@ -82,10 +83,10 @@ EXPECTED_TOOLS = [
     # sector_fx
     "analyze_sector_allocation",
     "analyze_fx_exposure",
-]
+}
 
-# 8 non-template resources (RESOURCE_ACCOUNTS is a template with {account_id})
-EXPECTED_RESOURCES = [
+# Non-template resources
+EXPECTED_RESOURCES = {
     RESOURCE_PORTFOLIO_LIST,
     RESOURCE_PORTFOLIO_LATEST,
     RESOURCE_TRADES_RECENT,
@@ -94,12 +95,12 @@ EXPECTED_RESOURCES = [
     RESOURCE_STRATEGY_REBALANCING,
     RESOURCE_STRATEGY_RISK,
     RESOURCE_USER_PROFILE,
-]
+}
 
-# 1 template resource
-EXPECTED_RESOURCE_TEMPLATES = [
+# Template resources
+EXPECTED_RESOURCE_TEMPLATES = {
     RESOURCE_ACCOUNTS,
-]
+}
 
 
 class TestMCPServerStartup:
@@ -110,6 +111,21 @@ class TestMCPServerStartup:
         """Create a server instance for testing (no network calls)"""
         return create_server()
 
+    @pytest.fixture(scope="class")
+    def registered_tools(self, server: FastMCP) -> dict[str, Any]:
+        """Fetch registered tools once for all tests in the class"""
+        return asyncio.run(server.get_tools())
+
+    @pytest.fixture(scope="class")
+    def registered_resources(self, server: FastMCP) -> dict[str, Any]:
+        """Fetch registered resources once for all tests in the class"""
+        return asyncio.run(server.get_resources())
+
+    @pytest.fixture(scope="class")
+    def registered_templates(self, server: FastMCP) -> dict[str, Any]:
+        """Fetch registered resource templates once for all tests in the class"""
+        return asyncio.run(server.get_resource_templates())
+
     def test_server_is_fastmcp_instance(self, server: FastMCP) -> None:
         """create_server() returns a FastMCP instance"""
         assert isinstance(server, FastMCP)
@@ -118,79 +134,26 @@ class TestMCPServerStartup:
         """Server is named ib-sec-mcp"""
         assert server.name == "ib-sec-mcp"
 
-    def test_all_45_tools_registered(self, server: FastMCP) -> None:
-        """All 45 tools are registered on the server"""
-        tools = asyncio.run(server.get_tools())
-        registered_names = set(tools.keys())
-        assert len(registered_names) == 45, (
-            f"Expected 45 tools, got {len(registered_names)}. "
-            f"Missing: {set(EXPECTED_TOOLS) - registered_names}"
+    def test_all_expected_tools_registered(self, registered_tools: dict[str, Any]) -> None:
+        """All expected tools are registered, with no extras or missing"""
+        registered_names = set(registered_tools.keys())
+        assert registered_names == EXPECTED_TOOLS, (
+            f"Missing: {EXPECTED_TOOLS - registered_names}, "
+            f"Unexpected: {registered_names - EXPECTED_TOOLS}"
         )
 
-    def test_spot_check_tools_registered(self, server: FastMCP) -> None:
-        """Spot-check: required tools from acceptance criteria are registered"""
-        tools = asyncio.run(server.get_tools())
-        registered_names = set(tools.keys())
-
-        required_tools = [
-            "generate_rebalancing_trades",
-            "analyze_sector_allocation",
-            "analyze_dividend_income",
-            "calculate_tax_loss_harvesting",
-            "analyze_fx_exposure",
-            "fetch_ib_data",
-            "get_trades",
-            "analyze_performance",
-            "compare_etf_performance",
-            "get_stock_analysis",
-        ]
-        for tool_name in required_tools:
-            assert tool_name in registered_names, f"Required tool '{tool_name}' not registered"
-
-    def test_all_expected_tool_names_registered(self, server: FastMCP) -> None:
-        """Every tool in the expected list is registered"""
-        tools = asyncio.run(server.get_tools())
-        registered_names = set(tools.keys())
-
-        missing = [t for t in EXPECTED_TOOLS if t not in registered_names]
-        assert not missing, f"Missing tools: {missing}"
-
-    def test_all_8_resources_registered(self, server: FastMCP) -> None:
-        """All 8 non-template resources are registered"""
-        resources = asyncio.run(server.get_resources())
-        registered_uris = set(resources.keys())
-
-        missing = [r for r in EXPECTED_RESOURCES if r not in registered_uris]
-        assert not missing, f"Missing resources: {missing}"
-        assert len(registered_uris) == len(EXPECTED_RESOURCES), (
-            f"Expected {len(EXPECTED_RESOURCES)} resources, got {len(registered_uris)}"
+    def test_all_resource_uris_registered(
+        self, registered_resources: dict[str, Any], registered_templates: dict[str, Any]
+    ) -> None:
+        """All expected resource URIs (static + templates) are registered"""
+        all_registered = set(registered_resources.keys()) | set(registered_templates.keys())
+        all_expected = EXPECTED_RESOURCES | EXPECTED_RESOURCE_TEMPLATES
+        assert all_registered == all_expected, (
+            f"Missing: {all_expected - all_registered}, Unexpected: {all_registered - all_expected}"
         )
-
-    def test_account_resource_template_registered(self, server: FastMCP) -> None:
-        """The ib://accounts/{account_id} template resource is registered"""
-        templates = asyncio.run(server.get_resource_templates())
-        registered_uris = set(templates.keys())
-
-        for template_uri in EXPECTED_RESOURCE_TEMPLATES:
-            assert template_uri in registered_uris, (
-                f"Template resource '{template_uri}' not registered"
-            )
-
-    def test_all_9_resource_uris_present(self, server: FastMCP) -> None:
-        """All 9 resource URIs (8 static + 1 template) are registered"""
-        resources = asyncio.run(server.get_resources())
-        templates = asyncio.run(server.get_resource_templates())
-
-        all_uris = set(resources.keys()) | set(templates.keys())
-        all_expected = set(EXPECTED_RESOURCES) | set(EXPECTED_RESOURCE_TEMPLATES)
-
-        missing = all_expected - all_uris
-        assert not missing, f"Missing resource URIs: {missing}"
-        assert len(all_uris) == 9, f"Expected 9 total resource URIs, got {len(all_uris)}"
 
     def test_server_starts_without_credentials(self) -> None:
         """Server creation requires no API credentials or network calls"""
-        # Should succeed with no environment variables set
         server = create_server(enable_debug=False)
         assert isinstance(server, FastMCP)
 


### PR DESCRIPTION
## Summary

- Creates `tests/mcp/test_server.py` to verify the MCP server starts correctly
- Asserts `create_server()` returns a `FastMCP` instance named `ib-sec-mcp`
- Asserts all 45 tools are registered (full list + spot-check of 10 required tools)
- Asserts all 9 resource URIs are registered (8 static + 1 `ib://accounts/{account_id}` template)
- Tests run without API credentials or network calls

## Changes

- `tests/mcp/test_server.py`: New test class `TestMCPServerStartup` with 10 test methods

## Testing

- ✅ Unit tests: 10 tests, all passing
- ✅ Formatting: ruff format (no changes needed)
- ✅ Linting: ruff check (all checks passed)
- ✅ Type checking: mypy (no issues found)
- ✅ No API credentials or network calls required

## Checklist

- [x] `pytest tests/mcp/test_server.py` passes
- [x] At least 10 tool names asserted (all 45 asserted)
- [x] All 9 resource URIs asserted
- [x] Test runs without API credentials

Resolves #52