### PR TITLE
feat: make rebalancing target allocation configurable via user profile (#54)

### DIFF
--- a/ib_sec_mcp/mcp/resources.py
+++ b/ib_sec_mcp/mcp/resources.py
@@ -158,11 +158,14 @@ def _get_target_allocation() -> dict[str, Decimal]:
         bonds = allocation_targets.get("bonds")
         cash = allocation_targets.get("cash")
         if stocks is not None and bonds is not None and cash is not None:
-            return {
-                "STK": Decimal(str(stocks)),
-                "BOND": Decimal(str(bonds)),
-                "CASH": Decimal(str(cash)),
-            }
+            try:
+                return {
+                    "STK": Decimal(str(stocks)),
+                    "BOND": Decimal(str(bonds)),
+                    "CASH": Decimal(str(cash)),
+                }
+            except (TypeError, ArithmeticError):
+                pass  # Fall through to profile type lookup
 
     # Priority 2: investment_profile.type mapped to predefined profile
     investment_profile = profile.get("investment_profile")


### PR DESCRIPTION
## Summary

- Reads target allocation in `ib://strategy/rebalancing-context` from `notes/investor-profile.yaml` instead of a hardcoded 60/35/5 split
- Supports four predefined profile types matching the `/rebalance-portfolio` command: `balanced` (50/40/10), `growth` (75/15/10), `conservative` (25/60/15), `income` (40/50/10)
- Supports explicit `allocation_targets` in YAML (overrides profile type)
- Falls back to 60% BOND / 35% STK / 5% CASH when no profile is configured (backward-compatible)

## Changes

**`ib_sec_mcp/mcp/resources.py`**
- Added `_DEFAULT_TARGET_ALLOCATION` and `_PROFILE_ALLOCATIONS` module-level constants
- Added `_get_target_allocation()` helper that reads from the user profile with graceful fallback
- Replaced 6-line hardcoded `target_allocation` block with a single `_get_target_allocation()` call
- Removed TODO comment (feature is now implemented)

**`tests/mcp/test_resources_rebalancing.py`** (new file)
- 19 unit tests covering all code paths: missing file, empty YAML, malformed YAML, unknown profile type, all four profile types (parametrized), explicit `allocation_targets`, precedence of explicit targets over type, partial targets fallback, Decimal type verification

## Testing

- ✅ New tests: 19/19 passing
- ✅ Full test suite: 620/620 passing
- ✅ `ruff format`: no changes needed
- ✅ `ruff check`: no issues
- ✅ `mypy`: no type errors (67 source files)
- ✅ Backward compatible: no profile = same 60/35/5 default as before

## Related

Resolves #54

## Checklist

- [x] Tests added and passing (19 new tests)
- [x] Decimal precision maintained throughout
- [x] Graceful fallback on all error conditions (missing file, bad YAML, unknown type)
- [x] Backward compatible (no profile = unchanged behavior)
- [x] Quality checks passing (ruff, mypy)