### PR TITLE
chore: update pre-commit hook versions (#61)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
   # Gitleaks - Secret scanning
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2
+    rev: v8.30.0
     hooks:
       - id: gitleaks
         name: Gitleaks - Secret Detection
@@ -15,7 +15,7 @@ repos:
 
   # Python code quality (Ruff handles linting, formatting, and import sorting)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.2
     hooks:
       - id: ruff
         name: Ruff - Linter & Import Sorter
@@ -25,7 +25,7 @@ repos:
 
   # Type checking (warning mode - errors don't block commits)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         name: mypy - Type Checker (warnings only)
@@ -54,7 +54,7 @@ repos:
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         name: Trim Trailing Whitespace
@@ -79,7 +79,7 @@ repos:
 
   # Security checks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.0
+    rev: 1.9.3
     hooks:
       - id: bandit
         name: Bandit - Security Linter
@@ -100,7 +100,7 @@ repos:
 
 # Configuration for specific hooks
 default_language_version:
-  python: python3.12
+  python: python3.13
 
 # Files to exclude from all hooks
 exclude: |

--- a/ib_sec_mcp/api/models.py
+++ b/ib_sec_mcp/api/models.py
@@ -2,12 +2,12 @@
 
 from datetime import date, datetime
 from decimal import Decimal
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 
-class FlexQueryStatus(str, Enum):
+class FlexQueryStatus(StrEnum):
     """Flex Query request status"""
 
     SUCCESS = "Success"

--- a/ib_sec_mcp/models/trade.py
+++ b/ib_sec_mcp/models/trade.py
@@ -2,19 +2,19 @@
 
 from datetime import date, datetime
 from decimal import Decimal
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 
-class BuySell(str, Enum):
+class BuySell(StrEnum):
     """Buy/Sell indicator"""
 
     BUY = "BUY"
     SELL = "SELL"
 
 
-class AssetClass(str, Enum):
+class AssetClass(StrEnum):
     """Asset class types"""
 
     STOCK = "STK"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
-    "ruff>=0.1.0",
-    "mypy>=1.8.0",
+    "ruff>=0.14.0",
+    "mypy>=1.19.0",
     "pre-commit>=4.0.0",
-    "bandit[toml]>=1.8.0",
+    "bandit[toml]>=1.9.0",
 ]
 visualization = [
     "plotly>=5.18.0",
@@ -75,7 +75,6 @@ target-version = "py312"
 select = ["E", "F", "I", "N", "W", "UP", "B", "A", "C4", "T20", "SIM"]
 ignore = [
     "E501",    # Line too long (handled by formatter)
-    "UP038",   # isinstance with tuple is fine
     "UP024",   # asyncio.TimeoutError is intentional for asyncio.wait_for
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -781,13 +781,13 @@ visualization = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'reporting'", specifier = ">=3.1.0" },
     { name = "kaleido", marker = "extra == 'visualization'", specifier = ">=0.2.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "plotly", marker = "extra == 'visualization'", specifier = ">=5.18.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -799,7 +799,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'mcp'", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=13.7.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
     { name = "scipy", marker = "extra == 'mcp'", specifier = ">=1.14.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "weasyprint", marker = "extra == 'reporting'", specifier = ">=60.0" },


### PR DESCRIPTION
## Summary

- Update all pre-commit hook versions to latest stable releases
- Align `pyproject.toml` dev dependency lower bounds with actual usage
- Fix code to comply with new ruff rules (UP042: `str, Enum` → `StrEnum`)

## Changes

### Pre-commit hook versions

| Hook | Before | After |
|------|--------|-------|
| ruff-pre-commit | v0.8.4 | v0.15.2 |
| mirrors-mypy | v1.13.0 | v1.19.1 |
| gitleaks | v8.27.2 | v8.30.0 |
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| bandit | 1.8.0 | 1.9.3 |

### Additional changes

- **`default_language_version`**: `python3.12` → `python3.13` (matches installed Python)
- **`StrEnum` migration**: `FlexQueryStatus`, `BuySell`, `AssetClass` now use `StrEnum` instead of `(str, Enum)` (ruff UP042)
- **Removed `UP038` ignore**: Rule was removed in ruff v0.15.x, ignore entry had no effect
- **Dev dependency bounds**: `ruff>=0.14.0`, `mypy>=1.19.0`, `bandit[toml]>=1.9.0`

## Test plan

- [x] `pre-commit run --all-files` — all 14 hooks pass
- [x] `pytest` — all 623 tests pass
- [x] No breaking changes from `pre-commit-hooks` v6.0.0 (removed hooks not used)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)