### PR TITLE
fix: add daily monitor tools to test_server expected tools set

### DIFF
--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -89,6 +89,9 @@ EXPECTED_TOOLS = {
     "get_pending_orders",
     "check_order_proximity",
     "get_order_history",
+    # daily_monitor
+    "sync_daily_snapshot",
+    "get_sync_status",
 }
 
 # Non-template resources


### PR DESCRIPTION
## Summary
- Add `sync_daily_snapshot` and `get_sync_status` to `EXPECTED_TOOLS` in `test_server.py`
- These tools were added in PR #81 but the test was not updated

## Test plan
- [x] `uv run pytest tests/mcp/test_server.py -v` passes
- [x] All 689 tests pass

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)