### PR TITLE
test: add MCP tool-level tests for limit order tools

### DIFF
--- a/ib_sec_mcp/mcp/tools/limit_orders.py
+++ b/ib_sec_mcp/mcp/tools/limit_orders.py
@@ -20,6 +20,8 @@ MARKET_SUFFIX_MAP: dict[str, str] = {
 def _get_yfinance_symbol(symbol: str, market: str) -> str:
     """Return the yfinance-compatible ticker for a given symbol and market."""
     suffix = MARKET_SUFFIX_MAP.get(market, "")
+    if suffix and symbol.endswith(suffix):
+        return symbol
     return f"{symbol}{suffix}"
 
 
@@ -314,20 +316,19 @@ def register_limit_order_tools(mcp: FastMCP) -> None:
         results = []
         alerts = []
 
-        # Group orders by symbol to minimize API calls
-        symbols: dict[str, list[dict[str, Any]]] = {}
+        # Group orders by (symbol, market) to minimize API calls
+        symbol_groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
         for order in orders:
-            sym = order["symbol"]
-            if sym not in symbols:
-                symbols[sym] = []
-            symbols[sym].append(order)
+            key = (order["symbol"], order["market"])
+            if key not in symbol_groups:
+                symbol_groups[key] = []
+            symbol_groups[key].append(order)
 
-        for sym, sym_orders in symbols.items():
+        for (sym, market), sym_orders in symbol_groups.items():
             current_price = None
             error_msg = None
 
             try:
-                market = sym_orders[0]["market"]
                 yf_symbol = _get_yfinance_symbol(sym, market)
                 ticker = yf.Ticker(yf_symbol)
                 info = ticker.info

--- a/tests/mcp/test_limit_orders.py
+++ b/tests/mcp/test_limit_orders.py
@@ -489,6 +489,51 @@ class TestCheckOrderProximity:
 
         assert Decimal(data["results"][0]["current_price"]) == Decimal("202")
 
+    @pytest.mark.asyncio
+    async def test_symbol_already_has_suffix_no_double_append(
+        self, test_mcp: FastMCP, tmp_path
+    ) -> None:
+        """Symbol stored with suffix (e.g., '1329.T') should not get double suffix."""
+        db_path = str(tmp_path / "test.db")
+        await _add_order(test_mcp, db_path, symbol="1329.T", market="TSE", limit_price="2500.00")
+
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker = MagicMock()
+            mock_ticker.info = {"currentPrice": 2550.0}
+            mock_ticker_cls.return_value = mock_ticker
+
+            tool = await test_mcp.get_tool("check_order_proximity")
+            await tool.fn(threshold_pct=5.0, db_path=db_path, ctx=None)
+
+        # Should be called with "1329.T", NOT "1329.T.T"
+        mock_ticker_cls.assert_called_once_with("1329.T")
+
+    @pytest.mark.asyncio
+    async def test_same_symbol_different_markets(self, test_mcp: FastMCP, tmp_path) -> None:
+        """Same symbol on different markets should make separate API calls."""
+        db_path = str(tmp_path / "test.db")
+        await _add_order(test_mcp, db_path, symbol="FOO", market="NYSE", limit_price="100.00")
+        await _add_order(test_mcp, db_path, symbol="FOO", market="LSE", limit_price="80.00")
+
+        call_args_list = []
+
+        def make_ticker(symbol: str) -> MagicMock:
+            call_args_list.append(symbol)
+            ticker = MagicMock()
+            ticker.info = {"currentPrice": 105.0}
+            return ticker
+
+        with patch("yfinance.Ticker", side_effect=make_ticker):
+            tool = await test_mcp.get_tool("check_order_proximity")
+            result = await tool.fn(threshold_pct=10.0, db_path=db_path, ctx=None)
+            data = json.loads(result)
+
+        # Two separate API calls: "FOO" (NYSE) and "FOO.L" (LSE)
+        assert len(call_args_list) == 2
+        assert "FOO" in call_args_list
+        assert "FOO.L" in call_args_list
+        assert data["total_orders"] == 2
+
 
 # ---------------------------------------------------------------------------
 # Tests: get_order_history


### PR DESCRIPTION
## Summary

- Add 28 functional tests in `tests/mcp/test_limit_orders.py` covering all 5 limit order MCP tools
- Fix symbol resolution bug in `check_order_proximity`: add market suffix mapping (LSE→`.L`, TSE→`.T`) for correct yfinance ticker lookup

## Changes

### New: `tests/mcp/test_limit_orders.py`
- **TestAddLimitOrder** (6 tests): all fields, minimal fields, invalid order_type/limit_price/quantity/date
- **TestUpdateLimitOrder** (6 tests): update price, fill with price/date, auto-set filled_date, cancel, invalid transition, nonexistent order
- **TestGetPendingOrders** (4 tests): all pending, filter by symbol, filter by market, empty
- **TestCheckOrderProximity** (9 tests): alert threshold, no alert, LSE/TSE/NYSE suffix mapping, multiple tranches single API call, yfinance failure graceful degradation, empty orders, fallback to regularMarketPrice
- **TestGetOrderHistory** (3 tests): all statuses, filter by symbol, empty

### Fix: `ib_sec_mcp/mcp/tools/limit_orders.py`
- Add `MARKET_SUFFIX_MAP` and `_get_yfinance_symbol()` helper
- Use suffix mapping in `check_order_proximity` so LSE symbols get `.L` suffix and TSE symbols get `.T` suffix

## Test plan

- [x] All 28 tests pass: `uv run pytest tests/mcp/test_limit_orders.py -v`
- [x] Full test suite passes: 717 passed
- [x] Coverage: 52.33% (above 48% threshold)
- [x] Lint clean: `ruff check` passes
- [x] yfinance calls are mocked (no real API calls)
- [x] Tests use temp SQLite DB (no side effects)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)