### PR TITLE
feat(api): add IB Client Portal API client with session management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ TOKEN=your_token_here
 # RAW_DATA_DIR=data/raw
 # PROCESSED_DATA_DIR=data/processed
 
+# Client Portal Gateway Configuration (optional)
+# Requires IB Gateway running locally
+# IB_GATEWAY_URL=https://localhost:5000
+# IB_GATEWAY_VERIFY_SSL=false
+
 # ==========================================
 # How to get your credentials:
 # ==========================================

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -102,6 +102,7 @@ regexes = [
     '''U7654321''',
     '''U1111111''',
     '''U2222222''',
+    '''U9999999''',
     '''U1234567''',  # Documentation example account ID
     '''U1234567''',  # Documentation example account ID
 

--- a/ib_sec_mcp/api/__init__.py
+++ b/ib_sec_mcp/api/__init__.py
@@ -1,6 +1,30 @@
-"""IB Flex Query API client module"""
+"""IB API client modules (Flex Query and Client Portal Gateway)"""
 
 from ib_sec_mcp.api.client import FlexQueryClient
+from ib_sec_mcp.api.cp_client import (
+    CPAuthenticationError,
+    CPClient,
+    CPClientError,
+    CPConnectionError,
+)
+from ib_sec_mcp.api.cp_models import (
+    CPAccountBalance,
+    CPAuthStatus,
+    CPOrder,
+    CPPosition,
+)
 from ib_sec_mcp.api.models import FlexQueryResponse, FlexStatement
 
-__all__ = ["FlexQueryClient", "FlexQueryResponse", "FlexStatement"]
+__all__ = [
+    "CPAccountBalance",
+    "CPAuthStatus",
+    "CPAuthenticationError",
+    "CPClient",
+    "CPClientError",
+    "CPConnectionError",
+    "CPOrder",
+    "CPPosition",
+    "FlexQueryClient",
+    "FlexQueryResponse",
+    "FlexStatement",
+]

--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -194,7 +194,7 @@ class CPClient:
             account_ids = []
             for item in data:
                 if isinstance(item, dict):
-                    acct_id = item.get("id", item.get("accountId", ""))
+                    acct_id = item.get("id") or item.get("accountId")
                     if acct_id:
                         account_ids.append(acct_id)
                 elif isinstance(item, str):

--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -1,0 +1,376 @@
+"""IB Client Portal Gateway API client with session management
+
+Provides async-only access to the IB Client Portal Gateway API for
+real-time account data, orders, and positions.
+
+Requires IB Gateway running locally with HTTPS enabled.
+"""
+
+import asyncio
+import os
+
+import httpx
+
+from ib_sec_mcp.api.cp_models import (
+    CPAccountBalance,
+    CPAuthStatus,
+    CPOrder,
+    CPPosition,
+)
+from ib_sec_mcp.utils.logger import get_logger, mask_sensitive
+
+logger = get_logger(__name__)
+
+
+class CPClientError(Exception):
+    """Base exception for Client Portal Gateway errors"""
+
+    pass
+
+
+class CPAuthenticationError(CPClientError):
+    """Authentication/session errors"""
+
+    pass
+
+
+class CPConnectionError(CPClientError):
+    """Connection errors (gateway unreachable)"""
+
+    pass
+
+
+class CPClient:
+    """
+    Async client for IB Client Portal Gateway API
+
+    Manages session authentication, TLS enforcement, and retry logic
+    for accessing real-time account data through the local IB Gateway.
+
+    Example:
+        async with CPClient() as client:
+            status = await client.check_auth_status()
+            if status.authenticated:
+                orders = await client.get_orders()
+
+    Environment Variables:
+        IB_GATEWAY_URL: Gateway URL (default: https://localhost:5000)
+        IB_GATEWAY_VERIFY_SSL: Verify SSL certificates (default: false)
+    """
+
+    USER_AGENT = "ib-analytics/0.1.0"
+
+    def __init__(
+        self,
+        gateway_url: str | None = None,
+        verify_ssl: bool | None = None,
+        max_retries: int = 3,
+        retry_delay: float = 1,
+    ):
+        """
+        Initialize Client Portal Gateway client
+
+        Args:
+            gateway_url: Gateway URL (default from IB_GATEWAY_URL env var)
+            verify_ssl: Verify SSL certificates (default from env var)
+            max_retries: Maximum retry attempts for failed requests
+            retry_delay: Base delay between retries in seconds
+
+        Raises:
+            CPClientError: If gateway_url uses http:// instead of https://
+        """
+        self.gateway_url = (
+            gateway_url or os.environ.get("IB_GATEWAY_URL", "https://localhost:5000")
+        ).rstrip("/")
+
+        # Enforce HTTPS
+        if self.gateway_url.startswith("http://"):
+            raise CPClientError(
+                f"HTTP is not allowed. Use https:// for gateway URL. Got: {self.gateway_url}"
+            )
+
+        if verify_ssl is not None:
+            self.verify_ssl = verify_ssl
+        else:
+            env_val = os.environ.get("IB_GATEWAY_VERIFY_SSL", "false")
+            self.verify_ssl = env_val.lower() in ("true", "1", "yes")
+
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> "CPClient":
+        """Create httpx async client on context entry"""
+        timeout = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=10.0)
+        self._client = httpx.AsyncClient(
+            base_url=self.gateway_url,
+            verify=self.verify_ssl,
+            timeout=timeout,
+            headers={"User-Agent": self.USER_AGENT},
+        )
+        logger.info(
+            "Connected to IB Gateway at %s (ssl_verify=%s)",
+            self.gateway_url,
+            self.verify_ssl,
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> None:
+        """Close httpx async client on context exit"""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+            logger.debug("Disconnected from IB Gateway")
+
+    async def check_auth_status(self) -> CPAuthStatus:
+        """
+        Check current authentication status
+
+        Returns:
+            CPAuthStatus with session information
+
+        Raises:
+            CPConnectionError: If gateway is unreachable
+            CPClientError: If request fails
+        """
+        data = await self._request("GET", "/v1/api/iserver/auth/status")
+        return CPAuthStatus.model_validate(data)
+
+    async def reauthenticate(self) -> bool:
+        """
+        Trigger reauthentication with the gateway
+
+        Returns:
+            True if reauthentication was successful
+
+        Raises:
+            CPAuthenticationError: If reauthentication fails
+        """
+        try:
+            data = await self._request("POST", "/v1/api/iserver/reauthenticate")
+            message = data.get("message", "")
+            logger.info("Reauthentication response: %s", message)
+            return True
+        except CPClientError as e:
+            raise CPAuthenticationError(f"Reauthentication failed: {e}") from e
+
+    async def get_orders(self) -> list[CPOrder]:
+        """
+        Get current orders
+
+        Returns:
+            List of CPOrder objects
+
+        Raises:
+            CPClientError: If request fails
+        """
+        await self._ensure_authenticated()
+        data = await self._request("GET", "/v1/api/iserver/account/orders")
+
+        # IB API returns {"orders": [...]} or just [...]
+        orders_data = data.get("orders", []) if isinstance(data, dict) else data
+        return [CPOrder.model_validate(o) for o in orders_data]
+
+    async def get_accounts(self) -> list[str]:
+        """
+        Get list of account IDs
+
+        Returns:
+            List of account ID strings
+
+        Raises:
+            CPClientError: If request fails
+        """
+        await self._ensure_authenticated()
+        data = await self._request("GET", "/v1/api/portfolio/accounts")
+
+        # IB API returns list of account objects with "id" field
+        if isinstance(data, list):
+            account_ids = []
+            for item in data:
+                if isinstance(item, dict):
+                    acct_id = item.get("id", item.get("accountId", ""))
+                    if acct_id:
+                        account_ids.append(acct_id)
+                elif isinstance(item, str):
+                    account_ids.append(item)
+            return account_ids
+        return []
+
+    async def get_account_balance(self, account_id: str) -> CPAccountBalance:
+        """
+        Get account balance summary
+
+        Args:
+            account_id: IB account ID
+
+        Returns:
+            CPAccountBalance with balance details
+
+        Raises:
+            CPClientError: If request fails
+        """
+        await self._ensure_authenticated()
+        logger.debug(
+            "Fetching balance for account %s",
+            mask_sensitive(account_id, show_chars=3),
+        )
+        data = await self._request("GET", f"/v1/api/portfolio/{account_id}/summary")
+
+        # IB API returns nested structure with {field: {amount: X}}
+        # Flatten to simple key-value for model validation
+        flat: dict[str, object] = {"account_id": account_id}
+        for key in (
+            "netliquidation",
+            "totalcashvalue",
+            "buyingpower",
+            "grosspositionvalue",
+        ):
+            if key in data and isinstance(data[key], dict):
+                flat[key] = data[key].get("amount", "0")
+            elif key in data:
+                flat[key] = data[key]
+
+        return CPAccountBalance.model_validate(flat)
+
+    async def get_positions(self, account_id: str) -> list[CPPosition]:
+        """
+        Get positions for an account
+
+        Args:
+            account_id: IB account ID
+
+        Returns:
+            List of CPPosition objects
+
+        Raises:
+            CPClientError: If request fails
+        """
+        await self._ensure_authenticated()
+        logger.debug(
+            "Fetching positions for account %s",
+            mask_sensitive(account_id, show_chars=3),
+        )
+        data = await self._request("GET", f"/v1/api/portfolio/{account_id}/positions/0")
+
+        if isinstance(data, list):
+            return [CPPosition.model_validate(p) for p in data]
+        return []
+
+    async def _ensure_authenticated(self) -> None:
+        """
+        Ensure session is authenticated, reauthenticate if needed
+
+        Raises:
+            CPAuthenticationError: If authentication cannot be established
+        """
+        try:
+            status = await self.check_auth_status()
+        except CPClientError as e:
+            raise CPAuthenticationError(f"Cannot verify auth status: {e}") from e
+
+        if not status.authenticated:
+            logger.warning("Session not authenticated, attempting reauth")
+            success = await self.reauthenticate()
+            if not success:
+                raise CPAuthenticationError("Failed to reauthenticate with gateway")
+
+            # Verify authentication after reauth
+            status = await self.check_auth_status()
+            if not status.authenticated:
+                raise CPAuthenticationError(
+                    "Session still not authenticated after reauthentication"
+                )
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        **kwargs: object,
+    ) -> dict:  # type: ignore[type-arg]
+        """
+        Make HTTP request with retry logic
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            path: API path (e.g., /v1/api/iserver/auth/status)
+            **kwargs: Additional arguments passed to httpx request
+
+        Returns:
+            Parsed JSON response as dict
+
+        Raises:
+            CPConnectionError: If gateway is unreachable
+            CPClientError: If request fails after retries
+        """
+        if not self._client:
+            raise CPClientError(
+                "Client not initialized. Use 'async with CPClient()' context manager."
+            )
+
+        last_error: Exception | None = None
+
+        for attempt in range(self.max_retries):
+            try:
+                response = await self._client.request(
+                    method,
+                    path,
+                    **kwargs,  # type: ignore[arg-type]
+                )
+                response.raise_for_status()
+                return response.json()  # type: ignore[no-any-return]
+
+            except httpx.ConnectError as e:
+                last_error = e
+                logger.warning(
+                    "Connection failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    self.max_retries,
+                    e,
+                )
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+
+            except httpx.HTTPStatusError as e:
+                status_code = e.response.status_code
+                if status_code == 401:
+                    raise CPAuthenticationError(f"Authentication required: {e}") from e
+                last_error = e
+                logger.warning(
+                    "HTTP %d error (attempt %d/%d): %s",
+                    status_code,
+                    attempt + 1,
+                    self.max_retries,
+                    e,
+                )
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+
+            except httpx.HTTPError as e:
+                last_error = e
+                logger.warning(
+                    "HTTP error (attempt %d/%d): %s",
+                    attempt + 1,
+                    self.max_retries,
+                    e,
+                )
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+
+        # All retries exhausted
+        if isinstance(last_error, httpx.ConnectError):
+            raise CPConnectionError(
+                f"Cannot connect to gateway at {self.gateway_url}: {last_error}"
+            ) from last_error
+
+        raise CPClientError(
+            f"Request failed after {self.max_retries} attempts: {last_error}"
+        ) from last_error

--- a/ib_sec_mcp/api/cp_models.py
+++ b/ib_sec_mcp/api/cp_models.py
@@ -1,0 +1,112 @@
+"""IB Client Portal Gateway API response models using Pydantic v2"""
+
+from decimal import Decimal
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class CPAuthStatus(BaseModel):
+    """Authentication status from Client Portal Gateway"""
+
+    authenticated: bool = Field(..., description="Whether session is authenticated")
+    competing: bool = Field(False, description="Whether competing session exists")
+    connected: bool = Field(False, description="Whether connected to server")
+    message: str = Field("", description="Status message")
+
+    class Config:
+        """Pydantic config"""
+
+        populate_by_name = True
+
+
+class CPOrderSide(StrEnum):
+    """Order side enumeration"""
+
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class CPOrderStatus(StrEnum):
+    """Order status enumeration"""
+
+    SUBMITTED = "Submitted"
+    FILLED = "Filled"
+    CANCELLED = "Cancelled"
+    INACTIVE = "Inactive"
+    PENDING_SUBMIT = "PendingSubmit"
+    PENDING_CANCEL = "PendingCancel"
+    PRE_SUBMITTED = "PreSubmitted"
+
+
+class CPOrder(BaseModel):
+    """Order from Client Portal Gateway"""
+
+    order_id: int = Field(..., alias="orderId", description="Order ID")
+    symbol: str = Field(..., description="Trading symbol")
+    side: str = Field(..., description="Order side (BUY/SELL)")
+    quantity: Decimal = Field(..., alias="totalSize", description="Order quantity")
+    price: Decimal = Field(Decimal("0"), alias="price", description="Limit price")
+    avg_price: Decimal = Field(Decimal("0"), alias="avgPrice", description="Average fill price")
+    status: str = Field(..., description="Order status")
+    order_type: str = Field("", alias="orderType", description="Order type")
+    account_id: str = Field("", alias="acct", description="Account ID")
+
+    class Config:
+        """Pydantic config"""
+
+        populate_by_name = True
+
+
+class CPAccountBalance(BaseModel):
+    """Account balance summary from Client Portal Gateway"""
+
+    account_id: str = Field(..., description="Account ID")
+    net_liquidation: Decimal = Field(
+        Decimal("0"),
+        alias="netliquidation",
+        description="Net liquidation value",
+    )
+    total_cash: Decimal = Field(
+        Decimal("0"),
+        alias="totalcashvalue",
+        description="Total cash value",
+    )
+    buying_power: Decimal = Field(
+        Decimal("0"),
+        alias="buyingpower",
+        description="Buying power",
+    )
+    gross_position_value: Decimal = Field(
+        Decimal("0"),
+        alias="grosspositionvalue",
+        description="Gross position value",
+    )
+
+    class Config:
+        """Pydantic config"""
+
+        populate_by_name = True
+
+
+class CPPosition(BaseModel):
+    """Position from Client Portal Gateway"""
+
+    account_id: str = Field(..., alias="acctId", description="Account ID")
+    contract_id: int = Field(..., alias="conid", description="Contract ID")
+    symbol: str = Field("", description="Trading symbol")
+    position: Decimal = Field(..., description="Position quantity")
+    market_price: Decimal = Field(Decimal("0"), alias="mktPrice", description="Market price")
+    market_value: Decimal = Field(Decimal("0"), alias="mktValue", description="Market value")
+    avg_cost: Decimal = Field(Decimal("0"), alias="avgCost", description="Average cost")
+    unrealized_pnl: Decimal = Field(
+        Decimal("0"),
+        alias="unrealizedPnl",
+        description="Unrealized P&L",
+    )
+    currency: str = Field("USD", description="Currency")
+
+    class Config:
+        """Pydantic config"""
+
+        populate_by_name = True

--- a/ib_sec_mcp/api/cp_models.py
+++ b/ib_sec_mcp/api/cp_models.py
@@ -3,21 +3,18 @@
 from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CPAuthStatus(BaseModel):
     """Authentication status from Client Portal Gateway"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     authenticated: bool = Field(..., description="Whether session is authenticated")
     competing: bool = Field(False, description="Whether competing session exists")
     connected: bool = Field(False, description="Whether connected to server")
     message: str = Field("", description="Status message")
-
-    class Config:
-        """Pydantic config"""
-
-        populate_by_name = True
 
 
 class CPOrderSide(StrEnum):
@@ -42,24 +39,23 @@ class CPOrderStatus(StrEnum):
 class CPOrder(BaseModel):
     """Order from Client Portal Gateway"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     order_id: int = Field(..., alias="orderId", description="Order ID")
     symbol: str = Field(..., description="Trading symbol")
-    side: str = Field(..., description="Order side (BUY/SELL)")
+    side: CPOrderSide = Field(..., description="Order side (BUY/SELL)")
     quantity: Decimal = Field(..., alias="totalSize", description="Order quantity")
     price: Decimal = Field(Decimal("0"), alias="price", description="Limit price")
     avg_price: Decimal = Field(Decimal("0"), alias="avgPrice", description="Average fill price")
-    status: str = Field(..., description="Order status")
+    status: CPOrderStatus = Field(..., description="Order status")
     order_type: str = Field("", alias="orderType", description="Order type")
     account_id: str = Field("", alias="acct", description="Account ID")
-
-    class Config:
-        """Pydantic config"""
-
-        populate_by_name = True
 
 
 class CPAccountBalance(BaseModel):
     """Account balance summary from Client Portal Gateway"""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     account_id: str = Field(..., description="Account ID")
     net_liquidation: Decimal = Field(
@@ -83,14 +79,11 @@ class CPAccountBalance(BaseModel):
         description="Gross position value",
     )
 
-    class Config:
-        """Pydantic config"""
-
-        populate_by_name = True
-
 
 class CPPosition(BaseModel):
     """Position from Client Portal Gateway"""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     account_id: str = Field(..., alias="acctId", description="Account ID")
     contract_id: int = Field(..., alias="conid", description="Contract ID")
@@ -105,8 +98,3 @@ class CPPosition(BaseModel):
         description="Unrealized P&L",
     )
     currency: str = Field("USD", description="Currency")
-
-    class Config:
-        """Pydantic config"""
-
-        populate_by_name = True

--- a/tests/api/test_cp_client.py
+++ b/tests/api/test_cp_client.py
@@ -1,0 +1,486 @@
+"""Tests for Client Portal Gateway API client"""
+
+import logging
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ib_sec_mcp.api.cp_client import (
+    CPAuthenticationError,
+    CPClient,
+    CPClientError,
+    CPConnectionError,
+)
+from ib_sec_mcp.api.cp_models import CPAccountBalance, CPAuthStatus, CPOrder, CPPosition
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_async_mock_response(
+    json_data: dict | list,  # type: ignore[type-arg]
+    status_code: int = 200,
+) -> MagicMock:
+    """Create a mock httpx.Response with JSON data"""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+
+    if status_code >= 400:
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=mock_response,
+        )
+    else:
+        mock.raise_for_status = MagicMock()
+
+    return mock
+
+
+AUTH_AUTHENTICATED = {
+    "authenticated": True,
+    "competing": False,
+    "connected": True,
+    "message": "",
+}
+
+AUTH_NOT_AUTHENTICATED = {
+    "authenticated": False,
+    "competing": False,
+    "connected": True,
+    "message": "Session expired",
+}
+
+REAUTH_SUCCESS = {"message": "triggered"}
+
+SAMPLE_ORDERS = {
+    "orders": [
+        {
+            "orderId": 100,
+            "symbol": "AAPL",
+            "side": "BUY",
+            "totalSize": "50",
+            "price": "150.00",
+            "avgPrice": "0",
+            "status": "Submitted",
+            "orderType": "LMT",
+            "acct": "U1234567",
+        },
+        {
+            "orderId": 101,
+            "symbol": "MSFT",
+            "side": "SELL",
+            "totalSize": "25",
+            "price": "300.00",
+            "avgPrice": "300.50",
+            "status": "Filled",
+            "orderType": "LMT",
+            "acct": "U1234567",
+        },
+    ]
+}
+
+SAMPLE_ACCOUNTS = [
+    {"id": "U1234567", "accountId": "U1234567"},
+    {"id": "U7654321", "accountId": "U7654321"},
+]
+
+SAMPLE_BALANCE = {
+    "netliquidation": {"amount": "1000000.50", "currency": "USD"},
+    "totalcashvalue": {"amount": "250000.75", "currency": "USD"},
+    "buyingpower": {"amount": "500000.00", "currency": "USD"},
+    "grosspositionvalue": {"amount": "750000.25", "currency": "USD"},
+}
+
+SAMPLE_POSITIONS = [
+    {
+        "acctId": "U1234567",
+        "conid": 265598,
+        "symbol": "AAPL",
+        "position": "100",
+        "mktPrice": "175.50",
+        "mktValue": "17550.00",
+        "avgCost": "150.25",
+        "unrealizedPnl": "2525.00",
+        "currency": "USD",
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cp_client() -> CPClient:
+    """Create a CPClient with test defaults"""
+    return CPClient(
+        gateway_url="https://localhost:5000",
+        verify_ssl=False,
+        max_retries=3,
+        retry_delay=0,
+    )
+
+
+@pytest.fixture
+def mock_httpx_client() -> AsyncMock:
+    """Create a mock httpx.AsyncClient"""
+    mock = AsyncMock()
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientInit
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientInit:
+    def test_default_url(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            client = CPClient()
+            assert client.gateway_url == "https://localhost:5000"
+
+    def test_custom_url(self) -> None:
+        client = CPClient(gateway_url="https://myhost:5001")
+        assert client.gateway_url == "https://myhost:5001"
+
+    def test_url_from_env(self) -> None:
+        with patch.dict("os.environ", {"IB_GATEWAY_URL": "https://envhost:9000"}):
+            client = CPClient()
+            assert client.gateway_url == "https://envhost:9000"
+
+    def test_url_trailing_slash_stripped(self) -> None:
+        client = CPClient(gateway_url="https://localhost:5000/")
+        assert client.gateway_url == "https://localhost:5000"
+
+    def test_http_url_rejected(self) -> None:
+        with pytest.raises(CPClientError, match="HTTP is not allowed"):
+            CPClient(gateway_url="http://localhost:5000")
+
+    def test_http_env_url_rejected(self) -> None:
+        with (
+            patch.dict("os.environ", {"IB_GATEWAY_URL": "http://insecure:5000"}),
+            pytest.raises(CPClientError, match="HTTP is not allowed"),
+        ):
+            CPClient()
+
+    def test_verify_ssl_default_false(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            client = CPClient()
+            assert client.verify_ssl is False
+
+    def test_verify_ssl_from_env_true(self) -> None:
+        with patch.dict("os.environ", {"IB_GATEWAY_VERIFY_SSL": "true"}):
+            client = CPClient()
+            assert client.verify_ssl is True
+
+    def test_verify_ssl_explicit(self) -> None:
+        client = CPClient(verify_ssl=True)
+        assert client.verify_ssl is True
+
+    def test_default_retries(self) -> None:
+        client = CPClient()
+        assert client.max_retries == 3
+        assert client.retry_delay == 1
+
+    def test_custom_retries(self) -> None:
+        client = CPClient(max_retries=5, retry_delay=2)
+        assert client.max_retries == 5
+        assert client.retry_delay == 2
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientAuthStatus
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientAuthStatus:
+    @pytest.mark.asyncio
+    async def test_check_auth_authenticated(self, cp_client: CPClient) -> None:
+        mock_response = make_async_mock_response(AUTH_AUTHENTICATED)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(return_value=mock_response)
+            status = await client.check_auth_status()
+
+            assert isinstance(status, CPAuthStatus)
+            assert status.authenticated is True
+            assert status.connected is True
+
+    @pytest.mark.asyncio
+    async def test_check_auth_expired(self, cp_client: CPClient) -> None:
+        mock_response = make_async_mock_response(AUTH_NOT_AUTHENTICATED)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(return_value=mock_response)
+            status = await client.check_auth_status()
+
+            assert status.authenticated is False
+            assert status.message == "Session expired"
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientReauthenticate
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientReauthenticate:
+    @pytest.mark.asyncio
+    async def test_reauthenticate_success(self, cp_client: CPClient) -> None:
+        mock_response = make_async_mock_response(REAUTH_SUCCESS)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(return_value=mock_response)
+            result = await client.reauthenticate()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_reauthenticate_failure(self, cp_client: CPClient) -> None:
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+            with pytest.raises(CPAuthenticationError, match="Reauthentication failed"):
+                await client.reauthenticate()
+
+    @pytest.mark.asyncio
+    async def test_ensure_authenticated_reauth_still_fails(self, cp_client: CPClient) -> None:
+        """Test that CPAuthenticationError is raised when reauth succeeds but session stays unauthenticated"""
+        not_auth_resp = make_async_mock_response(AUTH_NOT_AUTHENTICATED)
+        reauth_resp = make_async_mock_response(REAUTH_SUCCESS)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(
+                side_effect=[not_auth_resp, reauth_resp, not_auth_resp]
+            )
+            with pytest.raises(
+                CPAuthenticationError,
+                match="Session still not authenticated",
+            ):
+                await client._ensure_authenticated()
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientRetry
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientRetry:
+    @pytest.mark.asyncio
+    async def test_retry_succeeds_on_second_attempt(self, cp_client: CPClient) -> None:
+        fail_response = make_async_mock_response({}, status_code=500)
+        ok_response = make_async_mock_response({"status": "ok"})
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[fail_response, ok_response])
+            result = await client._request("GET", "/test")
+            assert result == {"status": "ok"}
+            assert client._client.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded(self, cp_client: CPClient) -> None:
+        fail_response = make_async_mock_response({}, status_code=500)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(
+                side_effect=[fail_response, fail_response, fail_response]
+            )
+            with pytest.raises(CPClientError, match="Request failed after 3 attempts"):
+                await client._request("GET", "/test")
+
+    @pytest.mark.asyncio
+    async def test_401_not_retried(self, cp_client: CPClient) -> None:
+        fail_response = make_async_mock_response({}, status_code=401)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(return_value=fail_response)
+            with pytest.raises(CPAuthenticationError, match="Authentication required"):
+                await client._request("GET", "/test")
+            assert client._client.request.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientOrders
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientOrders:
+    @pytest.mark.asyncio
+    async def test_get_orders(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        orders_response = make_async_mock_response(SAMPLE_ORDERS)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, orders_response])
+            orders = await client.get_orders()
+
+            assert len(orders) == 2
+            assert isinstance(orders[0], CPOrder)
+            assert orders[0].symbol == "AAPL"
+            assert orders[0].quantity == Decimal("50")
+            assert orders[1].symbol == "MSFT"
+            assert orders[1].status == "Filled"
+
+    @pytest.mark.asyncio
+    async def test_get_orders_empty(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        empty_response = make_async_mock_response({"orders": []})
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, empty_response])
+            orders = await client.get_orders()
+            assert orders == []
+
+    @pytest.mark.asyncio
+    async def test_get_orders_error(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        error_response = make_async_mock_response({}, status_code=500)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(
+                side_effect=[
+                    auth_response,
+                    error_response,
+                    error_response,
+                    error_response,
+                ]
+            )
+            with pytest.raises(CPClientError):
+                await client.get_orders()
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientAccounts
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientAccounts:
+    @pytest.mark.asyncio
+    async def test_get_accounts(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        accounts_response = make_async_mock_response(SAMPLE_ACCOUNTS)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, accounts_response])
+            accounts = await client.get_accounts()
+
+            assert len(accounts) == 2
+            assert "U1234567" in accounts
+            assert "U7654321" in accounts
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientBalance
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientBalance:
+    @pytest.mark.asyncio
+    async def test_get_account_balance(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        balance_response = make_async_mock_response(SAMPLE_BALANCE)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, balance_response])
+            balance = await client.get_account_balance("U1234567")
+
+            assert isinstance(balance, CPAccountBalance)
+            assert balance.account_id == "U1234567"
+            assert balance.net_liquidation == Decimal("1000000.5")
+            assert isinstance(balance.net_liquidation, Decimal)
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientPositions
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientPositions:
+    @pytest.mark.asyncio
+    async def test_get_positions(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        positions_response = make_async_mock_response(SAMPLE_POSITIONS)
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, positions_response])
+            positions = await client.get_positions("U1234567")
+
+            assert len(positions) == 1
+            assert isinstance(positions[0], CPPosition)
+            assert positions[0].symbol == "AAPL"
+            assert positions[0].position == Decimal("100")
+
+    @pytest.mark.asyncio
+    async def test_get_positions_empty(self, cp_client: CPClient) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        empty_response = make_async_mock_response([])
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, empty_response])
+            positions = await client.get_positions("U1234567")
+            assert positions == []
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientSecurity
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientSecurity:
+    def test_http_url_rejected(self) -> None:
+        with pytest.raises(CPClientError, match="HTTP is not allowed"):
+            CPClient(gateway_url="http://localhost:5000")
+
+    def test_https_url_accepted(self) -> None:
+        client = CPClient(gateway_url="https://localhost:5000")
+        assert client.gateway_url == "https://localhost:5000"
+
+    @pytest.mark.asyncio
+    async def test_account_number_masked_in_logs(
+        self, cp_client: CPClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        balance_response = make_async_mock_response(SAMPLE_BALANCE)
+
+        with caplog.at_level(logging.DEBUG, logger="ib_sec_mcp.api.cp_client"):
+            async with cp_client as client:
+                client._client.request = AsyncMock(side_effect=[auth_response, balance_response])
+                await client.get_account_balance("U1234567")
+
+        # Account number should be masked in logs
+        log_text = caplog.text
+        if "U1234567" in log_text:
+            # Full account number should not appear
+            pytest.fail("Full account number found in logs without masking")
+
+    @pytest.mark.asyncio
+    async def test_client_not_initialized_error(self, cp_client: CPClient) -> None:
+        # Do NOT use context manager — client is not initialized
+        with pytest.raises(CPClientError, match="Client not initialized"):
+            await cp_client._request("GET", "/test")
+
+
+# ---------------------------------------------------------------------------
+# TestCPClientConnection
+# ---------------------------------------------------------------------------
+
+
+class TestCPClientConnection:
+    @pytest.mark.asyncio
+    async def test_connection_refused(self, cp_client: CPClient) -> None:
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+            with pytest.raises(CPConnectionError, match="Cannot connect to gateway"):
+                await client._request("GET", "/test")
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, cp_client: CPClient) -> None:
+        assert cp_client._client is None
+        async with cp_client as client:
+            assert client._client is not None
+        assert cp_client._client is None

--- a/tests/api/test_cp_models.py
+++ b/tests/api/test_cp_models.py
@@ -1,0 +1,262 @@
+"""Tests for Client Portal Gateway API models"""
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from ib_sec_mcp.api.cp_models import (
+    CPAccountBalance,
+    CPAuthStatus,
+    CPOrder,
+    CPOrderSide,
+    CPOrderStatus,
+    CPPosition,
+)
+
+# ---------------------------------------------------------------------------
+# TestCPAuthStatus
+# ---------------------------------------------------------------------------
+
+
+class TestCPAuthStatus:
+    def test_authenticated_session(self) -> None:
+        status = CPAuthStatus(
+            authenticated=True,
+            competing=False,
+            connected=True,
+            message="",
+        )
+        assert status.authenticated is True
+        assert status.connected is True
+
+    def test_from_ib_json(self) -> None:
+        data = {
+            "authenticated": True,
+            "competing": False,
+            "connected": True,
+            "message": "Session active",
+        }
+        status = CPAuthStatus.model_validate(data)
+        assert status.authenticated is True
+        assert status.message == "Session active"
+
+    def test_defaults(self) -> None:
+        status = CPAuthStatus(authenticated=False)
+        assert status.competing is False
+        assert status.connected is False
+        assert status.message == ""
+
+    def test_required_authenticated_field(self) -> None:
+        with pytest.raises(ValidationError):
+            CPAuthStatus()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# TestCPOrderEnums
+# ---------------------------------------------------------------------------
+
+
+class TestCPOrderEnums:
+    def test_order_side_values(self) -> None:
+        assert CPOrderSide.BUY == "BUY"
+        assert CPOrderSide.SELL == "SELL"
+
+    def test_order_status_values(self) -> None:
+        assert CPOrderStatus.SUBMITTED == "Submitted"
+        assert CPOrderStatus.FILLED == "Filled"
+        assert CPOrderStatus.CANCELLED == "Cancelled"
+        assert CPOrderStatus.PRE_SUBMITTED == "PreSubmitted"
+
+
+# ---------------------------------------------------------------------------
+# TestCPOrder
+# ---------------------------------------------------------------------------
+
+
+class TestCPOrder:
+    def test_from_ib_json_with_aliases(self) -> None:
+        data = {
+            "orderId": 12345,
+            "symbol": "AAPL",
+            "side": "BUY",
+            "totalSize": "100",
+            "price": "150.50",
+            "avgPrice": "150.25",
+            "status": "Submitted",
+            "orderType": "LMT",
+            "acct": "U1234567",
+        }
+        order = CPOrder.model_validate(data)
+        assert order.order_id == 12345
+        assert order.symbol == "AAPL"
+        assert order.side == "BUY"
+        assert order.quantity == Decimal("100")
+        assert order.price == Decimal("150.50")
+        assert order.avg_price == Decimal("150.25")
+        assert order.status == "Submitted"
+        assert order.order_type == "LMT"
+        assert order.account_id == "U1234567"
+
+    def test_from_python_field_names(self) -> None:
+        order = CPOrder(
+            order_id=1,
+            symbol="MSFT",
+            side="SELL",
+            quantity=Decimal("50"),
+            status="Filled",
+        )
+        assert order.order_id == 1
+        assert order.quantity == Decimal("50")
+
+    def test_decimal_precision(self) -> None:
+        data = {
+            "orderId": 1,
+            "symbol": "AAPL",
+            "side": "BUY",
+            "totalSize": "100.5",
+            "price": "150.123456",
+            "avgPrice": "0",
+            "status": "Submitted",
+        }
+        order = CPOrder.model_validate(data)
+        assert order.price == Decimal("150.123456")
+        assert isinstance(order.price, Decimal)
+
+    def test_defaults(self) -> None:
+        data = {
+            "orderId": 1,
+            "symbol": "AAPL",
+            "side": "BUY",
+            "totalSize": "10",
+            "status": "Submitted",
+        }
+        order = CPOrder.model_validate(data)
+        assert order.price == Decimal("0")
+        assert order.avg_price == Decimal("0")
+        assert order.order_type == ""
+        assert order.account_id == ""
+
+    def test_required_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            CPOrder.model_validate({"symbol": "AAPL"})
+
+
+# ---------------------------------------------------------------------------
+# TestCPAccountBalance
+# ---------------------------------------------------------------------------
+
+
+class TestCPAccountBalance:
+    def test_from_ib_json_with_aliases(self) -> None:
+        data = {
+            "account_id": "U1234567",
+            "netliquidation": "1000000.50",
+            "totalcashvalue": "250000.75",
+            "buyingpower": "500000.00",
+            "grosspositionvalue": "750000.25",
+        }
+        balance = CPAccountBalance.model_validate(data)
+        assert balance.account_id == "U1234567"
+        assert balance.net_liquidation == Decimal("1000000.50")
+        assert balance.total_cash == Decimal("250000.75")
+        assert balance.buying_power == Decimal("500000.00")
+        assert balance.gross_position_value == Decimal("750000.25")
+
+    def test_decimal_types(self) -> None:
+        data = {
+            "account_id": "U1234567",
+            "netliquidation": "123.456789",
+        }
+        balance = CPAccountBalance.model_validate(data)
+        assert isinstance(balance.net_liquidation, Decimal)
+        assert balance.net_liquidation == Decimal("123.456789")
+
+    def test_defaults(self) -> None:
+        balance = CPAccountBalance(account_id="U1234567")
+        assert balance.net_liquidation == Decimal("0")
+        assert balance.total_cash == Decimal("0")
+        assert balance.buying_power == Decimal("0")
+        assert balance.gross_position_value == Decimal("0")
+
+    def test_required_account_id(self) -> None:
+        with pytest.raises(ValidationError):
+            CPAccountBalance()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# TestCPPosition
+# ---------------------------------------------------------------------------
+
+
+class TestCPPosition:
+    def test_from_ib_json_with_aliases(self) -> None:
+        data = {
+            "acctId": "U1234567",
+            "conid": 265598,
+            "symbol": "AAPL",
+            "position": "100",
+            "mktPrice": "175.50",
+            "mktValue": "17550.00",
+            "avgCost": "150.25",
+            "unrealizedPnl": "2525.00",
+            "currency": "USD",
+        }
+        pos = CPPosition.model_validate(data)
+        assert pos.account_id == "U1234567"
+        assert pos.contract_id == 265598
+        assert pos.symbol == "AAPL"
+        assert pos.position == Decimal("100")
+        assert pos.market_price == Decimal("175.50")
+        assert pos.market_value == Decimal("17550.00")
+        assert pos.avg_cost == Decimal("150.25")
+        assert pos.unrealized_pnl == Decimal("2525.00")
+        assert pos.currency == "USD"
+
+    def test_from_python_field_names(self) -> None:
+        pos = CPPosition(
+            account_id="U9999999",
+            contract_id=12345,
+            position=Decimal("50"),
+        )
+        assert pos.account_id == "U9999999"
+        assert pos.contract_id == 12345
+
+    def test_decimal_precision(self) -> None:
+        data = {
+            "acctId": "U1234567",
+            "conid": 1,
+            "position": "100.123456",
+            "mktPrice": "0.000001",
+        }
+        pos = CPPosition.model_validate(data)
+        assert pos.position == Decimal("100.123456")
+        assert pos.market_price == Decimal("0.000001")
+        assert isinstance(pos.market_price, Decimal)
+
+    def test_defaults(self) -> None:
+        pos = CPPosition(
+            account_id="U1234567",
+            contract_id=1,
+            position=Decimal("10"),
+        )
+        assert pos.symbol == ""
+        assert pos.market_price == Decimal("0")
+        assert pos.market_value == Decimal("0")
+        assert pos.avg_cost == Decimal("0")
+        assert pos.unrealized_pnl == Decimal("0")
+        assert pos.currency == "USD"
+
+    def test_negative_unrealized_pnl(self) -> None:
+        data = {
+            "acctId": "U1234567",
+            "conid": 1,
+            "position": "100",
+            "unrealizedPnl": "-500.75",
+        }
+        pos = CPPosition.model_validate(data)
+        assert pos.unrealized_pnl == Decimal("-500.75")
+
+    def test_required_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            CPPosition.model_validate({"symbol": "AAPL"})


### PR DESCRIPTION
## Summary

Implements #96 — IB Client Portal API client for real-time account data access through the local IB Gateway.

- **CPClient**: Async httpx client with session management, TLS enforcement, exponential backoff retry (3 attempts)
- **Pydantic Models**: CPAuthStatus, CPOrder, CPAccountBalance, CPPosition — all financial fields use `Decimal`
- **Security**: HTTPS-only (HTTP rejected), account number masking in logs, no credentials in code/logs
- **Exception Hierarchy**: CPClientError → CPAuthenticationError, CPConnectionError

## Changes

| File | Change |
|------|--------|
| `ib_sec_mcp/api/cp_client.py` | New — async client with auth, retry, TLS |
| `ib_sec_mcp/api/cp_models.py` | New — 4 Pydantic v2 models + 2 StrEnums |
| `ib_sec_mcp/api/__init__.py` | Updated exports |
| `.env.example` | Added CP Gateway env vars |
| `tests/api/test_cp_client.py` | New — 32 tests |
| `tests/api/test_cp_models.py` | New — 21 tests |

## Test Plan

- [x] 53 new tests pass (32 client + 21 model)
- [x] 570 total tests pass (no regressions)
- [x] mypy strict — no errors
- [x] ruff lint + format — clean
- [x] Security: HTTP URL rejection, account masking, no credential leakage
- [x] All 5 acceptance criteria verified by tests
- [ ] [manual] Paper Trading Gateway integration test

## Acceptance Criteria Coverage

| Criteria | Test |
|----------|------|
| CPConnectionError on gateway down | `test_connection_refused` |
| Auto-reauthentication on session expiry | `test_reauthenticate_success`, `test_ensure_authenticated_reauth_still_fails` |
| Pydantic model validation | 21 model tests |
| No credentials in logs | `test_account_number_masked_in_logs` |
| Existing Flex Query unaffected | Full regression suite passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)