### PR TITLE
feat(mcp): add live trading tools via Client Portal Gateway API

### DIFF
--- a/ib_sec_mcp/mcp/tools/__init__.py
+++ b/ib_sec_mcp/mcp/tools/__init__.py
@@ -18,6 +18,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from ib_sec_mcp.mcp.tools.etf_comparison import register_etf_comparison_tools
     from ib_sec_mcp.mcp.tools.ib_portfolio import register_ib_portfolio_tools
     from ib_sec_mcp.mcp.tools.limit_orders import register_limit_order_tools
+    from ib_sec_mcp.mcp.tools.live_trading import register_live_trading_tools
     from ib_sec_mcp.mcp.tools.market_comparison import register_market_comparison_tools
     from ib_sec_mcp.mcp.tools.options import register_options_tools
     from ib_sec_mcp.mcp.tools.portfolio_analytics import (
@@ -51,6 +52,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_rebalancing_tools(mcp)  # Add rebalancing tools
     register_sector_fx_tools(mcp)  # Add sector allocation and FX exposure tools
     register_limit_order_tools(mcp)  # Add limit order management tools
+    register_live_trading_tools(mcp)  # Add live trading tools via CP Gateway
     register_daily_monitor_tools(mcp)  # Add daily monitor tools
 
 

--- a/ib_sec_mcp/mcp/tools/live_trading.py
+++ b/ib_sec_mcp/mcp/tools/live_trading.py
@@ -10,7 +10,13 @@ from ib_sec_mcp.api.cp_client import (
     CPClient,
     CPConnectionError,
 )
-from ib_sec_mcp.api.cp_models import CPOrderSide, CPOrderStatus
+from ib_sec_mcp.api.cp_models import (
+    CPAccountBalance,
+    CPOrder,
+    CPOrderSide,
+    CPOrderStatus,
+    CPPosition,
+)
 
 GATEWAY_NOT_RUNNING_MSG = (
     "IB Client Portal Gateway is not running. Start the gateway and login at https://localhost:5000"
@@ -26,7 +32,7 @@ def _error_response(error: str) -> str:
     return json.dumps({"error": error}, indent=2)
 
 
-def _order_to_dict(order: Any) -> dict[str, Any]:
+def _order_to_dict(order: CPOrder) -> dict[str, Any]:
     """Convert a CPOrder to a serializable dict preserving Decimal as string."""
     return {
         "order_id": order.order_id,
@@ -41,7 +47,7 @@ def _order_to_dict(order: Any) -> dict[str, Any]:
     }
 
 
-def _position_to_dict(pos: Any) -> dict[str, Any]:
+def _position_to_dict(pos: CPPosition) -> dict[str, Any]:
     """Convert a CPPosition to a serializable dict preserving Decimal as string."""
     return {
         "account_id": pos.account_id,
@@ -56,7 +62,7 @@ def _position_to_dict(pos: Any) -> dict[str, Any]:
     }
 
 
-def _balance_to_dict(bal: Any) -> dict[str, Any]:
+def _balance_to_dict(bal: CPAccountBalance) -> dict[str, Any]:
     """Convert a CPAccountBalance to a serializable dict preserving Decimal as string."""
     return {
         "account_id": bal.account_id,
@@ -68,11 +74,11 @@ def _balance_to_dict(bal: Any) -> dict[str, Any]:
 
 
 def _filter_orders(
-    orders: list[Any],
+    orders: list[CPOrder],
     symbol: str | None = None,
     side: str | None = None,
     status: str | None = None,
-) -> list[Any]:
+) -> list[CPOrder]:
     """Filter orders by symbol, side, and status."""
     filtered = orders
     if symbol:
@@ -90,6 +96,19 @@ def _filter_orders(
         except ValueError:
             pass
     return filtered
+
+
+async def _resolve_account_id(client: CPClient, account_id: str | None) -> str | None:
+    """Resolve account ID, using first available account if not specified.
+
+    Returns the account ID or None if no accounts are found.
+    """
+    if account_id:
+        return account_id
+    accounts = await client.get_accounts()
+    if not accounts:
+        return None
+    return accounts[0]
 
 
 def register_live_trading_tools(mcp: FastMCP) -> None:
@@ -157,13 +176,11 @@ def register_live_trading_tools(mcp: FastMCP) -> None:
 
         try:
             async with CPClient() as client:
-                if not account_id:
-                    accounts = await client.get_accounts()
-                    if not accounts:
-                        return _error_response("No accounts found")
-                    account_id = accounts[0]
+                resolved_id = await _resolve_account_id(client, account_id)
+                if not resolved_id:
+                    return _error_response("No accounts found")
 
-                balance = await client.get_account_balance(account_id)
+                balance = await client.get_account_balance(resolved_id)
                 return json.dumps(_balance_to_dict(balance), indent=2)
         except CPConnectionError:
             return _error_response(GATEWAY_NOT_RUNNING_MSG)
@@ -192,16 +209,14 @@ def register_live_trading_tools(mcp: FastMCP) -> None:
 
         try:
             async with CPClient() as client:
-                if not account_id:
-                    accounts = await client.get_accounts()
-                    if not accounts:
-                        return _error_response("No accounts found")
-                    account_id = accounts[0]
+                resolved_id = await _resolve_account_id(client, account_id)
+                if not resolved_id:
+                    return _error_response("No accounts found")
 
-                positions = await client.get_positions(account_id)
+                positions = await client.get_positions(resolved_id)
                 return json.dumps(
                     {
-                        "account_id": account_id,
+                        "account_id": resolved_id,
                         "total_positions": len(positions),
                         "positions": [_position_to_dict(p) for p in positions],
                     },

--- a/ib_sec_mcp/mcp/tools/live_trading.py
+++ b/ib_sec_mcp/mcp/tools/live_trading.py
@@ -1,0 +1,259 @@
+"""Live trading MCP tools via IB Client Portal Gateway API"""
+
+import json
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from ib_sec_mcp.api.cp_client import (
+    CPAuthenticationError,
+    CPClient,
+    CPConnectionError,
+)
+from ib_sec_mcp.api.cp_models import CPOrderSide, CPOrderStatus
+
+GATEWAY_NOT_RUNNING_MSG = (
+    "IB Client Portal Gateway is not running. Start the gateway and login at https://localhost:5000"
+)
+
+SESSION_EXPIRED_MSG = (
+    "IB Client Portal session has expired. Please re-authenticate at https://localhost:5000"
+)
+
+
+def _error_response(error: str) -> str:
+    """Return a JSON error response."""
+    return json.dumps({"error": error}, indent=2)
+
+
+def _order_to_dict(order: Any) -> dict[str, Any]:
+    """Convert a CPOrder to a serializable dict preserving Decimal as string."""
+    return {
+        "order_id": order.order_id,
+        "symbol": order.symbol,
+        "side": str(order.side),
+        "quantity": str(order.quantity),
+        "limit_price": str(order.price),
+        "avg_price": str(order.avg_price),
+        "status": str(order.status),
+        "order_type": order.order_type,
+        "account_id": order.account_id,
+    }
+
+
+def _position_to_dict(pos: Any) -> dict[str, Any]:
+    """Convert a CPPosition to a serializable dict preserving Decimal as string."""
+    return {
+        "account_id": pos.account_id,
+        "contract_id": pos.contract_id,
+        "symbol": pos.symbol,
+        "quantity": str(pos.position),
+        "market_price": str(pos.market_price),
+        "market_value": str(pos.market_value),
+        "avg_cost": str(pos.avg_cost),
+        "unrealized_pnl": str(pos.unrealized_pnl),
+        "currency": pos.currency,
+    }
+
+
+def _balance_to_dict(bal: Any) -> dict[str, Any]:
+    """Convert a CPAccountBalance to a serializable dict preserving Decimal as string."""
+    return {
+        "account_id": bal.account_id,
+        "net_liquidation": str(bal.net_liquidation),
+        "total_cash": str(bal.total_cash),
+        "buying_power": str(bal.buying_power),
+        "gross_position_value": str(bal.gross_position_value),
+    }
+
+
+def _filter_orders(
+    orders: list[Any],
+    symbol: str | None = None,
+    side: str | None = None,
+    status: str | None = None,
+) -> list[Any]:
+    """Filter orders by symbol, side, and status."""
+    filtered = orders
+    if symbol:
+        filtered = [o for o in filtered if o.symbol.upper() == symbol.upper()]
+    if side:
+        try:
+            side_enum = CPOrderSide(side.upper())
+            filtered = [o for o in filtered if o.side == side_enum]
+        except ValueError:
+            pass
+    if status:
+        try:
+            status_enum = CPOrderStatus(status)
+            filtered = [o for o in filtered if o.status == status_enum]
+        except ValueError:
+            pass
+    return filtered
+
+
+def register_live_trading_tools(mcp: FastMCP) -> None:
+    """Register live trading tools via Client Portal Gateway"""
+
+    @mcp.tool
+    async def get_live_orders(
+        symbol: str | None = None,
+        side: str | None = None,
+        status: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Get live orders from IB Client Portal Gateway
+
+        Returns all active orders from the IB platform with optional filtering.
+
+        Args:
+            symbol: Filter by trading symbol (e.g., "AAPL")
+            side: Filter by order side ("BUY" or "SELL")
+            status: Filter by order status (e.g., "Submitted", "Filled")
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with list of live orders
+        """
+        if ctx:
+            await ctx.info("Fetching live orders from IB Gateway")
+
+        try:
+            async with CPClient() as client:
+                orders = await client.get_orders()
+                filtered = _filter_orders(orders, symbol=symbol, side=side, status=status)
+                return json.dumps(
+                    {
+                        "total_orders": len(filtered),
+                        "orders": [_order_to_dict(o) for o in filtered],
+                    },
+                    indent=2,
+                )
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+
+    @mcp.tool
+    async def get_live_account_balance(
+        account_id: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Get real-time account balance from IB Client Portal Gateway
+
+        Returns total value, cash, buying power, and margin information.
+
+        Args:
+            account_id: IB account ID (optional, uses first account if not specified)
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with account balance details
+        """
+        if ctx:
+            await ctx.info("Fetching account balance from IB Gateway")
+
+        try:
+            async with CPClient() as client:
+                if not account_id:
+                    accounts = await client.get_accounts()
+                    if not accounts:
+                        return _error_response("No accounts found")
+                    account_id = accounts[0]
+
+                balance = await client.get_account_balance(account_id)
+                return json.dumps(_balance_to_dict(balance), indent=2)
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+
+    @mcp.tool
+    async def get_live_positions(
+        account_id: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Get real-time positions from IB Client Portal Gateway
+
+        Returns symbol, quantity, market value, average cost, and unrealized P&L.
+
+        Args:
+            account_id: IB account ID (optional, uses first account if not specified)
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with list of positions
+        """
+        if ctx:
+            await ctx.info("Fetching positions from IB Gateway")
+
+        try:
+            async with CPClient() as client:
+                if not account_id:
+                    accounts = await client.get_accounts()
+                    if not accounts:
+                        return _error_response("No accounts found")
+                    account_id = accounts[0]
+
+                positions = await client.get_positions(account_id)
+                return json.dumps(
+                    {
+                        "account_id": account_id,
+                        "total_positions": len(positions),
+                        "positions": [_position_to_dict(p) for p in positions],
+                    },
+                    indent=2,
+                )
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+
+    @mcp.tool
+    async def check_gateway_status(
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Check IB Client Portal Gateway connection status
+
+        Returns connection state, authentication status, and session information.
+
+        Args:
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with gateway status
+        """
+        if ctx:
+            await ctx.info("Checking IB Gateway status")
+
+        try:
+            async with CPClient() as client:
+                auth_status = await client.check_auth_status()
+                return json.dumps(
+                    {
+                        "connected": True,
+                        "authenticated": auth_status.authenticated,
+                        "competing": auth_status.competing,
+                        "server_connected": auth_status.connected,
+                        "message": auth_status.message,
+                    },
+                    indent=2,
+                )
+        except CPConnectionError:
+            return json.dumps(
+                {
+                    "connected": False,
+                    "authenticated": False,
+                    "competing": False,
+                    "server_connected": False,
+                    "message": GATEWAY_NOT_RUNNING_MSG,
+                },
+                indent=2,
+            )
+
+
+__all__ = ["register_live_trading_tools"]

--- a/tests/mcp/test_live_trading.py
+++ b/tests/mcp/test_live_trading.py
@@ -1,0 +1,513 @@
+"""Tests for live trading MCP tools via Client Portal Gateway"""
+
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.api.cp_client import CPAuthenticationError, CPConnectionError
+from ib_sec_mcp.api.cp_models import (
+    CPAccountBalance,
+    CPAuthStatus,
+    CPOrder,
+    CPOrderSide,
+    CPOrderStatus,
+    CPPosition,
+)
+from ib_sec_mcp.mcp.tools.live_trading import (
+    _balance_to_dict,
+    _filter_orders,
+    _order_to_dict,
+    _position_to_dict,
+    register_live_trading_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with live trading tools registered."""
+    mcp = FastMCP("test")
+    register_live_trading_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def mock_orders() -> list[CPOrder]:
+    """Sample CPOrder objects."""
+    return [
+        CPOrder(
+            orderId=1,
+            symbol="AAPL",
+            side=CPOrderSide.BUY,
+            totalSize=Decimal("100"),
+            price=Decimal("150.50"),
+            avgPrice=Decimal("0"),
+            status=CPOrderStatus.SUBMITTED,
+            orderType="LMT",
+            acct="U1234567",
+        ),
+        CPOrder(
+            orderId=2,
+            symbol="MSFT",
+            side=CPOrderSide.SELL,
+            totalSize=Decimal("50"),
+            price=Decimal("400.00"),
+            avgPrice=Decimal("380.25"),
+            status=CPOrderStatus.FILLED,
+            orderType="LMT",
+            acct="U1234567",
+        ),
+    ]
+
+
+@pytest.fixture()
+def mock_positions() -> list[CPPosition]:
+    """Sample CPPosition objects."""
+    return [
+        CPPosition(
+            acctId="U1234567",
+            conid=265598,
+            symbol="AAPL",
+            position=Decimal("100"),
+            mktPrice=Decimal("155.30"),
+            mktValue=Decimal("15530.00"),
+            avgCost=Decimal("150.50"),
+            unrealizedPnl=Decimal("480.00"),
+            currency="USD",
+        ),
+    ]
+
+
+@pytest.fixture()
+def mock_balance() -> CPAccountBalance:
+    """Sample CPAccountBalance object."""
+    return CPAccountBalance(
+        account_id="U1234567",
+        netliquidation=Decimal("100000.50"),
+        totalcashvalue=Decimal("25000.75"),
+        buyingpower=Decimal("50000.00"),
+        grosspositionvalue=Decimal("75000.25"),
+    )
+
+
+@pytest.fixture()
+def mock_auth_status() -> CPAuthStatus:
+    """Sample CPAuthStatus object."""
+    return CPAuthStatus(
+        authenticated=True,
+        competing=False,
+        connected=True,
+        message="Session active",
+    )
+
+
+def _mock_cp_client(
+    orders: list[CPOrder] | None = None,
+    positions: list[CPPosition] | None = None,
+    balance: CPAccountBalance | None = None,
+    auth_status: CPAuthStatus | None = None,
+    accounts: list[str] | None = None,
+) -> MagicMock:
+    """Create a mock CPClient as async context manager."""
+    client = AsyncMock()
+    client.get_orders = AsyncMock(return_value=orders if orders is not None else [])
+    client.get_positions = AsyncMock(return_value=positions if positions is not None else [])
+    client.get_account_balance = AsyncMock(return_value=balance)
+    client.check_auth_status = AsyncMock(return_value=auth_status)
+    client.get_accounts = AsyncMock(return_value=accounts if accounts is not None else ["U1234567"])
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Tests: Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+class TestOrderToDict:
+    """Tests for _order_to_dict helper."""
+
+    def test_converts_decimal_fields_to_strings(self, mock_orders: list[CPOrder]) -> None:
+        result = _order_to_dict(mock_orders[0])
+        assert result["quantity"] == "100"
+        assert result["limit_price"] == "150.50"
+        assert result["avg_price"] == "0"
+
+    def test_preserves_string_fields(self, mock_orders: list[CPOrder]) -> None:
+        result = _order_to_dict(mock_orders[0])
+        assert result["symbol"] == "AAPL"
+        assert result["order_id"] == 1
+        assert result["account_id"] == "U1234567"
+
+
+class TestPositionToDict:
+    """Tests for _position_to_dict helper."""
+
+    def test_converts_decimal_fields_to_strings(self, mock_positions: list[CPPosition]) -> None:
+        result = _position_to_dict(mock_positions[0])
+        assert result["quantity"] == "100"
+        assert result["market_price"] == "155.30"
+        assert result["unrealized_pnl"] == "480.00"
+
+    def test_preserves_non_decimal_fields(self, mock_positions: list[CPPosition]) -> None:
+        result = _position_to_dict(mock_positions[0])
+        assert result["symbol"] == "AAPL"
+        assert result["currency"] == "USD"
+
+
+class TestBalanceToDict:
+    """Tests for _balance_to_dict helper."""
+
+    def test_converts_decimal_fields_to_strings(self, mock_balance: CPAccountBalance) -> None:
+        result = _balance_to_dict(mock_balance)
+        assert result["net_liquidation"] == "100000.50"
+        assert result["total_cash"] == "25000.75"
+        assert result["buying_power"] == "50000.00"
+        assert result["gross_position_value"] == "75000.25"
+
+
+class TestFilterOrders:
+    """Tests for _filter_orders helper."""
+
+    def test_no_filters(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders)
+        assert len(result) == 2
+
+    def test_filter_by_symbol(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, symbol="AAPL")
+        assert len(result) == 1
+        assert result[0].symbol == "AAPL"
+
+    def test_filter_by_symbol_case_insensitive(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, symbol="aapl")
+        assert len(result) == 1
+
+    def test_filter_by_side(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, side="SELL")
+        assert len(result) == 1
+        assert result[0].side == CPOrderSide.SELL
+
+    def test_filter_by_status(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, status="Submitted")
+        assert len(result) == 1
+        assert result[0].status == CPOrderStatus.SUBMITTED
+
+    def test_combined_filters(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, symbol="AAPL", side="BUY")
+        assert len(result) == 1
+
+    def test_invalid_side_returns_all(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, side="INVALID")
+        assert len(result) == 2
+
+    def test_invalid_status_returns_all(self, mock_orders: list[CPOrder]) -> None:
+        result = _filter_orders(mock_orders, status="INVALID")
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_live_orders
+# ---------------------------------------------------------------------------
+
+
+class TestGetLiveOrders:
+    """Tests for the get_live_orders MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_all_orders(self, test_mcp: FastMCP, mock_orders: list[CPOrder]) -> None:
+        mock_cm = _mock_cp_client(orders=mock_orders)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["total_orders"] == 2
+        assert len(data["orders"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_filter_by_symbol(self, test_mcp: FastMCP, mock_orders: list[CPOrder]) -> None:
+        mock_cm = _mock_cp_client(orders=mock_orders)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_orders")
+            result = await tool.fn(symbol="AAPL", ctx=None)
+            data = json.loads(result)
+
+        assert data["total_orders"] == 1
+        assert data["orders"][0]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_decimal_precision_in_response(
+        self, test_mcp: FastMCP, mock_orders: list[CPOrder]
+    ) -> None:
+        mock_cm = _mock_cp_client(orders=mock_orders)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        order = data["orders"][0]
+        # Values should be string representations of Decimal
+        Decimal(order["limit_price"])
+        Decimal(order["quantity"])
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_running(self, test_mcp: FastMCP) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPConnectionError("unreachable"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "not running" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_session_expired(self, test_mcp: FastMCP) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPAuthenticationError("expired"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "expired" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_orders(self, test_mcp: FastMCP) -> None:
+        mock_cm = _mock_cp_client(orders=[])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["total_orders"] == 0
+        assert data["orders"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_live_account_balance
+# ---------------------------------------------------------------------------
+
+
+class TestGetLiveAccountBalance:
+    """Tests for the get_live_account_balance MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_balance_with_explicit_account(
+        self, test_mcp: FastMCP, mock_balance: CPAccountBalance
+    ) -> None:
+        mock_cm = _mock_cp_client(balance=mock_balance)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_account_balance")
+            result = await tool.fn(account_id="U1234567", ctx=None)
+            data = json.loads(result)
+
+        assert data["account_id"] == "U1234567"
+        assert Decimal(data["net_liquidation"]) == Decimal("100000.50")
+        assert Decimal(data["total_cash"]) == Decimal("25000.75")
+
+    @pytest.mark.asyncio
+    async def test_auto_selects_first_account(
+        self, test_mcp: FastMCP, mock_balance: CPAccountBalance
+    ) -> None:
+        mock_cm = _mock_cp_client(balance=mock_balance, accounts=["U1234567", "U7654321"])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_account_balance")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["account_id"] == "U1234567"
+
+    @pytest.mark.asyncio
+    async def test_no_accounts_found(self, test_mcp: FastMCP) -> None:
+        mock_cm = _mock_cp_client(accounts=[])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_account_balance")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "No accounts" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_running(self, test_mcp: FastMCP) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPConnectionError("unreachable"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_account_balance")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "not running" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_decimal_precision(
+        self, test_mcp: FastMCP, mock_balance: CPAccountBalance
+    ) -> None:
+        mock_cm = _mock_cp_client(balance=mock_balance)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_account_balance")
+            result = await tool.fn(account_id="U1234567", ctx=None)
+            data = json.loads(result)
+
+        # All financial values should be parseable as Decimal
+        for field in ["net_liquidation", "total_cash", "buying_power", "gross_position_value"]:
+            Decimal(data[field])
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_live_positions
+# ---------------------------------------------------------------------------
+
+
+class TestGetLivePositions:
+    """Tests for the get_live_positions MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_positions(
+        self, test_mcp: FastMCP, mock_positions: list[CPPosition]
+    ) -> None:
+        mock_cm = _mock_cp_client(positions=mock_positions, accounts=["U1234567"])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_positions")
+            result = await tool.fn(account_id="U1234567", ctx=None)
+            data = json.loads(result)
+
+        assert data["account_id"] == "U1234567"
+        assert data["total_positions"] == 1
+        pos = data["positions"][0]
+        assert pos["symbol"] == "AAPL"
+        assert Decimal(pos["unrealized_pnl"]) == Decimal("480.00")
+
+    @pytest.mark.asyncio
+    async def test_auto_selects_first_account(
+        self, test_mcp: FastMCP, mock_positions: list[CPPosition]
+    ) -> None:
+        mock_cm = _mock_cp_client(positions=mock_positions, accounts=["U1234567"])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_positions")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["account_id"] == "U1234567"
+
+    @pytest.mark.asyncio
+    async def test_no_accounts_found(self, test_mcp: FastMCP) -> None:
+        mock_cm = _mock_cp_client(accounts=[])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_positions")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_running(self, test_mcp: FastMCP) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPConnectionError("unreachable"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_positions")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "not running" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_decimal_precision(
+        self, test_mcp: FastMCP, mock_positions: list[CPPosition]
+    ) -> None:
+        mock_cm = _mock_cp_client(positions=mock_positions, accounts=["U1234567"])
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("get_live_positions")
+            result = await tool.fn(account_id="U1234567", ctx=None)
+            data = json.loads(result)
+
+        pos = data["positions"][0]
+        for field in ["quantity", "market_price", "market_value", "avg_cost", "unrealized_pnl"]:
+            Decimal(pos[field])
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_gateway_status
+# ---------------------------------------------------------------------------
+
+
+class TestCheckGatewayStatus:
+    """Tests for the check_gateway_status MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_gateway_connected_and_authenticated(
+        self, test_mcp: FastMCP, mock_auth_status: CPAuthStatus
+    ) -> None:
+        mock_cm = _mock_cp_client(auth_status=mock_auth_status)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("check_gateway_status")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["connected"] is True
+        assert data["authenticated"] is True
+        assert data["competing"] is False
+        assert data["server_connected"] is True
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_running(self, test_mcp: FastMCP) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPConnectionError("unreachable"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("check_gateway_status")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["connected"] is False
+        assert data["authenticated"] is False
+        assert "not running" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_authenticated(self, test_mcp: FastMCP) -> None:
+        unauth_status = CPAuthStatus(
+            authenticated=False,
+            competing=False,
+            connected=True,
+            message="Not authenticated",
+        )
+        mock_cm = _mock_cp_client(auth_status=unauth_status)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("check_gateway_status")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["connected"] is True
+        assert data["authenticated"] is False
+
+    @pytest.mark.asyncio
+    async def test_response_is_valid_json(
+        self, test_mcp: FastMCP, mock_auth_status: CPAuthStatus
+    ) -> None:
+        mock_cm = _mock_cp_client(auth_status=mock_auth_status)
+        with patch("ib_sec_mcp.mcp.tools.live_trading.CPClient", return_value=mock_cm):
+            tool = await test_mcp.get_tool("check_gateway_status")
+            result = await tool.fn(ctx=None)
+
+        data = json.loads(result)
+        assert isinstance(data, dict)
+        for key in ["connected", "authenticated", "competing", "server_connected", "message"]:
+            assert key in data

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -89,6 +89,11 @@ EXPECTED_TOOLS = {
     "get_pending_orders",
     "check_order_proximity",
     "get_order_history",
+    # live_trading
+    "get_live_orders",
+    "get_live_account_balance",
+    "get_live_positions",
+    "check_gateway_status",
     # daily_monitor
     "sync_daily_snapshot",
     "get_sync_status",


### PR DESCRIPTION
## Summary

- Add 4 MCP tools for real-time IB data via Client Portal Gateway API
- `get_live_orders` — active orders with symbol/side/status filters
- `get_live_account_balance` — real-time balance (auto-selects first account)
- `get_live_positions` — positions with unrealized P&L
- `check_gateway_status` — connection/auth status check
- Graceful error handling: gateway down or session expired returns JSON errors, no impact on existing tools

Closes #93

## Changes

| File | Change |
|------|--------|
| `ib_sec_mcp/mcp/tools/live_trading.py` | New — 4 MCP tools + module-level helpers |
| `ib_sec_mcp/mcp/tools/__init__.py` | Register live trading tools |
| `tests/mcp/test_live_trading.py` | 33 tests: happy path, error handling, Decimal precision |
| `tests/mcp/test_server.py` | Add 4 tool names to EXPECTED_TOOLS |

## Test plan

- [x] 33 unit tests all passing (mocked CP client)
- [x] Server registration test passes (4 new tools in EXPECTED_TOOLS)
- [x] All 236 MCP tests pass (no regressions)
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy type check clean
- [ ] [manual] [integration] Paper Trading: `check_gateway_status` → `get_live_orders` with live gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)