### PR TITLE
feat(sync): add limit order DB sync with live IB orders via CP API

### DIFF
--- a/ib_sec_mcp/mcp/tools/limit_orders.py
+++ b/ib_sec_mcp/mcp/tools/limit_orders.py
@@ -438,5 +438,74 @@ def register_limit_order_tools(mcp: FastMCP) -> None:
             default=str,
         )
 
+    @mcp.tool
+    async def sync_limit_orders(
+        db_path: str = "data/processed/limit_orders.db",
+        gateway_url: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Sync limit orders from IB Client Portal Gateway to local DB
+
+        Fetches live orders from IB and synchronizes with local limit_orders.db:
+        - New IB orders not in DB → added
+        - IB filled orders → DB status updated to FILLED
+        - IB cancelled orders → DB status updated to CANCELLED
+        - Existing matches → skipped
+
+        Requires IB Client Portal Gateway to be running. If Gateway is not
+        reachable, returns a skip message (no error).
+
+        Args:
+            db_path: Path to SQLite database
+            gateway_url: IB Gateway URL override (default: from env or https://localhost:5000)
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with sync results (added, updated, skipped, errors)
+
+        Example:
+            >>> result = await sync_limit_orders()
+        """
+        from ib_sec_mcp.storage.order_sync import try_sync_from_ib
+
+        if ctx:
+            await ctx.info("Starting limit order sync from IB Gateway")
+
+        store = LimitOrderStore(db_path)
+        try:
+            sync_result = await try_sync_from_ib(
+                store=store,
+                gateway_url=gateway_url,
+            )
+
+            if sync_result is None:
+                if ctx:
+                    await ctx.info("IB Gateway not available, sync skipped")
+                return json.dumps(
+                    {
+                        "status": "skipped",
+                        "message": "IB Gateway not available or not authenticated",
+                    },
+                    indent=2,
+                )
+
+            if ctx:
+                await ctx.info(
+                    f"Sync complete: {sync_result.added} added, "
+                    f"{sync_result.updated} updated, "
+                    f"{sync_result.skipped} skipped"
+                )
+
+            return json.dumps(
+                {
+                    "status": "completed",
+                    "sync_result": sync_result.to_dict(),
+                },
+                indent=2,
+            )
+        finally:
+            store.close()
+
 
 __all__ = ["register_limit_order_tools"]

--- a/ib_sec_mcp/storage/order_sync.py
+++ b/ib_sec_mcp/storage/order_sync.py
@@ -64,21 +64,20 @@ def _map_ib_status(status: CPOrderStatus) -> str | None:
     return None
 
 
-def _find_matching_order(
-    pending_orders: list[dict[str, object]],
-    symbol: str,
-    limit_price: Decimal,
-    order_type: str,
-) -> dict[str, object] | None:
-    """Find a matching local order by symbol + limit_price + order_type"""
-    for order in pending_orders:
-        if (
-            order["symbol"] == symbol
-            and order["limit_price"] == limit_price
-            and order["order_type"] == order_type
-        ):
-            return order
-    return None
+OrderKey = tuple[object, Decimal, object]
+"""Match key: (symbol, limit_price, order_type)"""
+
+
+def _build_order_map(
+    orders: list[dict[str, object]],
+) -> dict[OrderKey, dict[str, object]]:
+    """Build a dict map keyed by (symbol, limit_price, order_type) for O(1) lookup"""
+    result: dict[OrderKey, dict[str, object]] = {}
+    for order in orders:
+        key: OrderKey = (order["symbol"], Decimal(str(order["limit_price"])), order["order_type"])
+        if key not in result:
+            result[key] = order
+    return result
 
 
 async def sync_orders_from_ib(
@@ -111,9 +110,13 @@ async def sync_orders_from_ib(
     all_local_orders = store.get_order_history()
     pending_orders = [o for o in all_local_orders if o["status"] == "PENDING"]
 
+    # Build dict maps for O(1) lookup instead of O(N) list iteration
+    pending_map = _build_order_map(pending_orders)
+    all_orders_map = _build_order_map(all_local_orders)
+
     for ib_order in ib_orders:
         try:
-            _process_single_order(ib_order, pending_orders, all_local_orders, store, result)
+            _process_single_order(ib_order, pending_map, all_orders_map, store, result)
         except Exception as e:
             result.errors.append(f"Error processing order {ib_order.symbol}: {e}")
 
@@ -129,8 +132,8 @@ async def sync_orders_from_ib(
 
 def _process_single_order(
     ib_order: CPOrder,
-    pending_orders: list[dict[str, object]],
-    all_local_orders: list[dict[str, object]],
+    pending_map: dict[OrderKey, dict[str, object]],
+    all_orders_map: dict[OrderKey, dict[str, object]],
     store: LimitOrderStore,
     result: SyncResult,
 ) -> None:
@@ -140,13 +143,14 @@ def _process_single_order(
     order_type = _map_ib_side(ib_order.side)
     db_status = _map_ib_status(ib_order.status)
 
+    key: OrderKey = (symbol, limit_price, order_type)
+
     # Try to find matching order in pending orders first
-    matched = _find_matching_order(pending_orders, symbol, limit_price, order_type)
+    matched = pending_map.get(key)
 
     if matched is None:
         # Also check all orders (including terminal) to avoid re-adding
-        matched_any = _find_matching_order(all_local_orders, symbol, limit_price, order_type)
-        if matched_any is not None:
+        if key in all_orders_map:
             # Already exists (possibly already filled/cancelled)
             result.skipped += 1
             return
@@ -164,11 +168,14 @@ def _process_single_order(
                 notes="Synced from IB",
             )
             # If the order is already filled on IB, update status
-            if db_status == "FILLED" and ib_order.avg_price > Decimal("0"):
+            if db_status == "FILLED":
+                filled_price = (
+                    ib_order.avg_price if ib_order.avg_price > Decimal("0") else limit_price
+                )
                 store.update_order(
                     order_id=order_id,
                     status="FILLED",
-                    filled_price=ib_order.avg_price,
+                    filled_price=filled_price,
                     filled_date=date.today(),
                 )
             result.added += 1

--- a/ib_sec_mcp/storage/order_sync.py
+++ b/ib_sec_mcp/storage/order_sync.py
@@ -1,0 +1,254 @@
+"""Sync limit orders between IB Client Portal Gateway and local DB
+
+Provides one-way sync from IB live orders to local limit_orders.db.
+Matching logic: symbol + limit_price + order_type (BUY/SELL).
+Conflict resolution: IB data is source of truth.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+
+from ib_sec_mcp.api.cp_client import CPClient, CPConnectionError
+from ib_sec_mcp.api.cp_models import CPOrder, CPOrderSide, CPOrderStatus
+from ib_sec_mcp.storage.limit_order_store import LimitOrderStore
+from ib_sec_mcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class SyncResult:
+    """Result of a sync operation"""
+
+    added: int = 0
+    updated: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total_processed(self) -> int:
+        return self.added + self.updated + self.skipped
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "added": self.added,
+            "updated": self.updated,
+            "skipped": self.skipped,
+            "errors": self.errors,
+            "total_processed": self.total_processed,
+        }
+
+
+def _map_ib_side(side: CPOrderSide) -> str:
+    """Map IB order side to local DB order_type"""
+    return "BUY" if side == CPOrderSide.BUY else "SELL"
+
+
+def _map_ib_status(status: CPOrderStatus) -> str | None:
+    """Map IB order status to local DB status, or None if no update needed"""
+    if status == CPOrderStatus.FILLED:
+        return "FILLED"
+    if status == CPOrderStatus.CANCELLED:
+        return "CANCELLED"
+    if status in (
+        CPOrderStatus.SUBMITTED,
+        CPOrderStatus.PRE_SUBMITTED,
+        CPOrderStatus.PENDING_SUBMIT,
+    ):
+        return None  # Still active, no status change needed
+    if status == CPOrderStatus.INACTIVE:
+        return "CANCELLED"
+    if status == CPOrderStatus.PENDING_CANCEL:
+        return None  # Not yet cancelled
+    return None
+
+
+def _find_matching_order(
+    pending_orders: list[dict[str, object]],
+    symbol: str,
+    limit_price: Decimal,
+    order_type: str,
+) -> dict[str, object] | None:
+    """Find a matching local order by symbol + limit_price + order_type"""
+    for order in pending_orders:
+        if (
+            order["symbol"] == symbol
+            and order["limit_price"] == limit_price
+            and order["order_type"] == order_type
+        ):
+            return order
+    return None
+
+
+async def sync_orders_from_ib(
+    cp_client: CPClient,
+    store: LimitOrderStore,
+) -> SyncResult:
+    """Sync IB live orders to local DB
+
+    - New orders (IB has, DB doesn't) → add to DB
+    - Filled orders (IB FILLED) → update DB status to FILLED
+    - Cancelled orders (IB CANCELLED) → update DB status to CANCELLED
+    - Existing match with same status → skip
+
+    Args:
+        cp_client: Authenticated CPClient instance
+        store: LimitOrderStore instance
+
+    Returns:
+        SyncResult with counts of added/updated/skipped/errors
+    """
+    result = SyncResult()
+
+    try:
+        ib_orders = await cp_client.get_orders()
+    except Exception as e:
+        result.errors.append(f"Failed to fetch IB orders: {e}")
+        return result
+
+    # Get all local orders (pending + history) for matching
+    all_local_orders = store.get_order_history()
+    pending_orders = [o for o in all_local_orders if o["status"] == "PENDING"]
+
+    for ib_order in ib_orders:
+        try:
+            _process_single_order(ib_order, pending_orders, all_local_orders, store, result)
+        except Exception as e:
+            result.errors.append(f"Error processing order {ib_order.symbol}: {e}")
+
+    logger.info(
+        "Sync complete: added=%d, updated=%d, skipped=%d, errors=%d",
+        result.added,
+        result.updated,
+        result.skipped,
+        len(result.errors),
+    )
+    return result
+
+
+def _process_single_order(
+    ib_order: CPOrder,
+    pending_orders: list[dict[str, object]],
+    all_local_orders: list[dict[str, object]],
+    store: LimitOrderStore,
+    result: SyncResult,
+) -> None:
+    """Process a single IB order for sync"""
+    symbol = ib_order.symbol
+    limit_price = ib_order.price
+    order_type = _map_ib_side(ib_order.side)
+    db_status = _map_ib_status(ib_order.status)
+
+    # Try to find matching order in pending orders first
+    matched = _find_matching_order(pending_orders, symbol, limit_price, order_type)
+
+    if matched is None:
+        # Also check all orders (including terminal) to avoid re-adding
+        matched_any = _find_matching_order(all_local_orders, symbol, limit_price, order_type)
+        if matched_any is not None:
+            # Already exists (possibly already filled/cancelled)
+            result.skipped += 1
+            return
+
+        # New order: add to DB if it's an active order
+        if db_status is None or db_status == "FILLED":
+            # Active or filled IB order not in our DB → add it
+            order_id = store.add_order(
+                symbol=symbol,
+                market="",  # IB doesn't provide market in order response
+                order_type=order_type,
+                limit_price=limit_price,
+                created_date=date.today(),
+                quantity=ib_order.quantity,
+                notes="Synced from IB",
+            )
+            # If the order is already filled on IB, update status
+            if db_status == "FILLED" and ib_order.avg_price > Decimal("0"):
+                store.update_order(
+                    order_id=order_id,
+                    status="FILLED",
+                    filled_price=ib_order.avg_price,
+                    filled_date=date.today(),
+                )
+            result.added += 1
+        elif db_status == "CANCELLED":
+            # Don't add cancelled orders that were never in our DB
+            result.skipped += 1
+        else:
+            result.skipped += 1
+        return
+
+    # Matched existing pending order
+    if db_status is None:
+        # Still active on IB, no change needed
+        result.skipped += 1
+        return
+
+    matched_id: int = matched["id"]  # type: ignore[assignment]
+
+    if db_status == "FILLED":
+        filled_price = ib_order.avg_price if ib_order.avg_price > Decimal("0") else limit_price
+        store.update_order(
+            order_id=matched_id,
+            status="FILLED",
+            filled_price=filled_price,
+            filled_date=date.today(),
+        )
+        result.updated += 1
+    elif db_status == "CANCELLED":
+        store.update_order(
+            order_id=matched_id,
+            status="CANCELLED",
+        )
+        result.updated += 1
+    else:
+        result.skipped += 1
+
+
+async def sync_orders_to_ib(
+    cp_client: CPClient,
+    store: LimitOrderStore,
+) -> SyncResult:
+    """Sync local DB orders to IB (Phase 2 — not yet implemented)
+
+    Args:
+        cp_client: Authenticated CPClient instance
+        store: LimitOrderStore instance
+
+    Raises:
+        NotImplementedError: Always, as this is reserved for Phase 2
+    """
+    raise NotImplementedError("sync_orders_to_ib is reserved for Phase 2")
+
+
+async def try_sync_from_ib(
+    store: LimitOrderStore,
+    gateway_url: str | None = None,
+) -> SyncResult | None:
+    """Attempt to sync from IB, returning None if Gateway is not running
+
+    This is the safe entry point for automated sync (e.g., /daily-check).
+    It gracefully handles the case where Gateway is not running.
+
+    Args:
+        store: LimitOrderStore instance
+        gateway_url: Optional gateway URL override
+
+    Returns:
+        SyncResult if sync was performed, None if Gateway was unreachable
+    """
+    try:
+        async with CPClient(gateway_url=gateway_url, max_retries=1) as client:
+            # Quick auth check — if it fails, Gateway is likely not running
+            status = await client.check_auth_status()
+            if not status.authenticated:
+                logger.info("IB Gateway not authenticated, skipping sync")
+                return None
+            return await sync_orders_from_ib(client, store)
+    except CPConnectionError:
+        logger.info("IB Gateway not reachable, skipping order sync")
+        return None
+    except Exception as e:
+        logger.warning("Unexpected error during order sync: %s", e)
+        return None

--- a/tests/mcp/test_limit_orders.py
+++ b/tests/mcp/test_limit_orders.py
@@ -616,3 +616,78 @@ class TestGetOrderHistory:
         assert data["total_orders"] == 0
         assert data["status_summary"] == {}
         assert data["orders"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_limit_orders
+# ---------------------------------------------------------------------------
+
+
+class TestSyncLimitOrders:
+    """Tests for the sync_limit_orders MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_available_returns_skipped(self, test_mcp: FastMCP, tmp_path) -> None:
+        """When Gateway is not running, should return skipped status."""
+        from unittest.mock import AsyncMock, patch
+
+        db_path = str(tmp_path / "test.db")
+
+        with patch(
+            "ib_sec_mcp.storage.order_sync.try_sync_from_ib",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            tool = await test_mcp.get_tool("sync_limit_orders")
+            result = await tool.fn(db_path=db_path, ctx=None)
+            data = json.loads(result)
+
+        assert data["status"] == "skipped"
+        assert "not available" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_successful_sync(self, test_mcp: FastMCP, tmp_path) -> None:
+        """Successful sync should return completed status with counts."""
+        from unittest.mock import AsyncMock, patch
+
+        from ib_sec_mcp.storage.order_sync import SyncResult
+
+        db_path = str(tmp_path / "test.db")
+        mock_result = SyncResult(added=2, updated=1, skipped=3)
+
+        with patch(
+            "ib_sec_mcp.storage.order_sync.try_sync_from_ib",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            tool = await test_mcp.get_tool("sync_limit_orders")
+            result = await tool.fn(db_path=db_path, ctx=None)
+            data = json.loads(result)
+
+        assert data["status"] == "completed"
+        assert data["sync_result"]["added"] == 2
+        assert data["sync_result"]["updated"] == 1
+        assert data["sync_result"]["skipped"] == 3
+        assert data["sync_result"]["total_processed"] == 6
+
+    @pytest.mark.asyncio
+    async def test_sync_with_errors(self, test_mcp: FastMCP, tmp_path) -> None:
+        """Sync with errors should include error details."""
+        from unittest.mock import AsyncMock, patch
+
+        from ib_sec_mcp.storage.order_sync import SyncResult
+
+        db_path = str(tmp_path / "test.db")
+        mock_result = SyncResult(added=1, errors=["Failed to process AAPL"])
+
+        with patch(
+            "ib_sec_mcp.storage.order_sync.try_sync_from_ib",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            tool = await test_mcp.get_tool("sync_limit_orders")
+            result = await tool.fn(db_path=db_path, ctx=None)
+            data = json.loads(result)
+
+        assert data["status"] == "completed"
+        assert data["sync_result"]["errors"] == ["Failed to process AAPL"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -89,6 +89,7 @@ EXPECTED_TOOLS = {
     "get_pending_orders",
     "check_order_proximity",
     "get_order_history",
+    "sync_limit_orders",
     # daily_monitor
     "sync_daily_snapshot",
     "get_sync_status",

--- a/tests/storage/test_order_sync.py
+++ b/tests/storage/test_order_sync.py
@@ -1,0 +1,525 @@
+"""Tests for order sync logic (IB → local DB)"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ib_sec_mcp.api.cp_client import CPConnectionError
+from ib_sec_mcp.api.cp_models import CPAuthStatus, CPOrder, CPOrderSide, CPOrderStatus
+from ib_sec_mcp.storage.limit_order_store import LimitOrderStore
+from ib_sec_mcp.storage.order_sync import (
+    SyncResult,
+    sync_orders_from_ib,
+    sync_orders_to_ib,
+    try_sync_from_ib,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path) -> LimitOrderStore:
+    """Fresh LimitOrderStore with test DB"""
+    return LimitOrderStore(tmp_path / "test.db")
+
+
+@pytest.fixture()
+def mock_cp_client() -> AsyncMock:
+    """Mock CPClient"""
+    client = AsyncMock()
+    client.get_orders = AsyncMock(return_value=[])
+    client.check_auth_status = AsyncMock(
+        return_value=CPAuthStatus(authenticated=True, connected=True)
+    )
+    return client
+
+
+def _make_ib_order(
+    symbol: str = "CSPX",
+    side: CPOrderSide = CPOrderSide.BUY,
+    price: str = "700.00",
+    quantity: str = "10",
+    status: CPOrderStatus = CPOrderStatus.SUBMITTED,
+    avg_price: str = "0",
+    order_id: int = 1001,
+) -> CPOrder:
+    """Create a CPOrder for testing"""
+    return CPOrder(
+        orderId=order_id,
+        symbol=symbol,
+        side=side,
+        totalSize=Decimal(quantity),
+        price=Decimal(price),
+        avgPrice=Decimal(avg_price),
+        status=status,
+        orderType="LMT",
+        acct="U1234567",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: SyncResult
+# ---------------------------------------------------------------------------
+
+
+class TestSyncResult:
+    def test_empty_result(self) -> None:
+        result = SyncResult()
+        assert result.added == 0
+        assert result.updated == 0
+        assert result.skipped == 0
+        assert result.errors == []
+        assert result.total_processed == 0
+
+    def test_to_dict(self) -> None:
+        result = SyncResult(added=2, updated=1, skipped=3, errors=["err1"])
+        d = result.to_dict()
+        assert d["added"] == 2
+        assert d["updated"] == 1
+        assert d["skipped"] == 3
+        assert d["errors"] == ["err1"]
+        assert d["total_processed"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_orders_from_ib — new orders
+# ---------------------------------------------------------------------------
+
+
+class TestSyncNewOrders:
+    @pytest.mark.asyncio
+    async def test_new_ib_order_added_to_db(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """IB order not in DB should be added"""
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(symbol="CSPX", price="700.00", status=CPOrderStatus.SUBMITTED)
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.added == 1
+        assert result.updated == 0
+        orders = store.get_pending_orders()
+        assert len(orders) == 1
+        assert orders[0]["symbol"] == "CSPX"
+        assert orders[0]["limit_price"] == Decimal("700.00")
+        assert orders[0]["order_type"] == "BUY"
+        assert orders[0]["notes"] == "Synced from IB"
+
+    @pytest.mark.asyncio
+    async def test_multiple_new_orders_added(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """Multiple new IB orders should all be added"""
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(symbol="CSPX", price="700.00", order_id=1001),
+            _make_ib_order(symbol="VWRA", price="100.00", order_id=1002),
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.added == 2
+        orders = store.get_pending_orders()
+        assert len(orders) == 2
+
+    @pytest.mark.asyncio
+    async def test_new_filled_order_added_with_status(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """New IB order already filled should be added with FILLED status"""
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                price="700.00",
+                status=CPOrderStatus.FILLED,
+                avg_price="695.50",
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.added == 1
+        history = store.get_order_history(symbol="CSPX")
+        assert len(history) == 1
+        assert history[0]["status"] == "FILLED"
+        assert history[0]["filled_price"] == Decimal("695.50")
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_orders_from_ib — filled orders
+# ---------------------------------------------------------------------------
+
+
+class TestSyncFilledOrders:
+    @pytest.mark.asyncio
+    async def test_pending_order_filled_on_ib(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """Pending local order that is filled on IB should be updated"""
+        from datetime import date
+
+        # Add a pending order locally
+        store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                price="700.00",
+                status=CPOrderStatus.FILLED,
+                avg_price="698.00",
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.updated == 1
+        history = store.get_order_history(symbol="CSPX")
+        assert history[0]["status"] == "FILLED"
+        assert history[0]["filled_price"] == Decimal("698.00")
+
+    @pytest.mark.asyncio
+    async def test_filled_order_uses_limit_price_when_no_avg(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """When avg_price is 0, filled_price should fall back to limit_price"""
+        from datetime import date
+
+        store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                price="700.00",
+                status=CPOrderStatus.FILLED,
+                avg_price="0",
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.updated == 1
+        history = store.get_order_history(symbol="CSPX")
+        assert history[0]["filled_price"] == Decimal("700.00")
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_orders_from_ib — cancelled orders
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCancelledOrders:
+    @pytest.mark.asyncio
+    async def test_pending_order_cancelled_on_ib(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """Pending local order cancelled on IB should be updated"""
+        from datetime import date
+
+        store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                price="700.00",
+                status=CPOrderStatus.CANCELLED,
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.updated == 1
+        history = store.get_order_history(symbol="CSPX")
+        assert history[0]["status"] == "CANCELLED"
+
+    @pytest.mark.asyncio
+    async def test_inactive_order_treated_as_cancelled(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """IB Inactive status should be treated as CANCELLED"""
+        from datetime import date
+
+        store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                price="700.00",
+                status=CPOrderStatus.INACTIVE,
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.updated == 1
+        history = store.get_order_history(symbol="CSPX")
+        assert history[0]["status"] == "CANCELLED"
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_orders_from_ib — matching and skipping
+# ---------------------------------------------------------------------------
+
+
+class TestSyncMatching:
+    @pytest.mark.asyncio
+    async def test_existing_pending_order_no_change(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """Active IB order matching pending local order → skip"""
+        from datetime import date
+
+        store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(symbol="CSPX", price="700.00", status=CPOrderStatus.SUBMITTED)
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.skipped == 1
+        assert result.added == 0
+        assert result.updated == 0
+
+    @pytest.mark.asyncio
+    async def test_matching_by_side(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """BUY and SELL at same price/symbol should not match"""
+        from datetime import date
+
+        store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+
+        # IB has a SELL order at same price
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                side=CPOrderSide.SELL,
+                price="700.00",
+                status=CPOrderStatus.SUBMITTED,
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        # Should add as new (SELL doesn't match BUY)
+        assert result.added == 1
+        orders = store.get_pending_orders()
+        assert len(orders) == 2
+
+    @pytest.mark.asyncio
+    async def test_cancelled_ib_order_not_in_db_skipped(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """Cancelled IB order with no local match should be skipped"""
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(symbol="CSPX", price="700.00", status=CPOrderStatus.CANCELLED)
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.skipped == 1
+        assert result.added == 0
+
+    @pytest.mark.asyncio
+    async def test_already_filled_in_db_skipped(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """IB order matching an already-filled local order should be skipped"""
+        from datetime import date
+
+        order_id = store.add_order(
+            symbol="CSPX",
+            market="LSE",
+            order_type="BUY",
+            limit_price=Decimal("700.00"),
+            created_date=date.today(),
+        )
+        store.update_order(
+            order_id=order_id,
+            status="FILLED",
+            filled_price=Decimal("695.00"),
+            filled_date=date.today(),
+        )
+
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(symbol="CSPX", price="700.00", status=CPOrderStatus.FILLED)
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.skipped == 1
+        assert result.added == 0
+        assert result.updated == 0
+
+    @pytest.mark.asyncio
+    async def test_manual_orders_unaffected(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """Manual orders not in IB should remain untouched"""
+        from datetime import date
+
+        store.add_order(
+            symbol="MANUAL_STOCK",
+            market="NYSE",
+            order_type="BUY",
+            limit_price=Decimal("50.00"),
+            created_date=date.today(),
+            notes="Manual entry",
+        )
+
+        # IB has different orders
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(symbol="CSPX", price="700.00", status=CPOrderStatus.SUBMITTED)
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.added == 1  # CSPX added
+        # Manual order still pending
+        manual = store.get_pending_orders(symbol="MANUAL_STOCK")
+        assert len(manual) == 1
+        assert manual[0]["notes"] == "Manual entry"
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_orders_from_ib — error handling
+# ---------------------------------------------------------------------------
+
+
+class TestSyncErrorHandling:
+    @pytest.mark.asyncio
+    async def test_ib_api_failure(self, mock_cp_client: AsyncMock, store: LimitOrderStore) -> None:
+        """Failure to fetch IB orders should return error in result"""
+        mock_cp_client.get_orders.side_effect = Exception("API timeout")
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert len(result.errors) == 1
+        assert "API timeout" in result.errors[0]
+        assert result.added == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_ib_orders(self, mock_cp_client: AsyncMock, store: LimitOrderStore) -> None:
+        """Empty IB orders list should result in no changes"""
+        mock_cp_client.get_orders.return_value = []
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.added == 0
+        assert result.updated == 0
+        assert result.skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: sync_orders_to_ib (Phase 2 stub)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncToIB:
+    @pytest.mark.asyncio
+    async def test_raises_not_implemented(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="Phase 2"):
+            await sync_orders_to_ib(mock_cp_client, store)
+
+
+# ---------------------------------------------------------------------------
+# Tests: try_sync_from_ib (Gateway-safe wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestTrySyncFromIB:
+    @pytest.mark.asyncio
+    async def test_gateway_not_reachable_returns_none(self, store: LimitOrderStore) -> None:
+        """When Gateway is not running, should return None (no error)"""
+        with patch("ib_sec_mcp.storage.order_sync.CPClient", autospec=True) as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.check_auth_status.side_effect = CPConnectionError("refused")
+
+            # CPConnectionError during check_auth_status should be caught by the
+            # except block, but actually the ensure_authenticated is called inside
+            # get_orders. Let's mock the context manager properly.
+            mock_ctx = AsyncMock()
+            mock_ctx.check_auth_status.side_effect = CPConnectionError("Connection refused")
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+
+            result = await try_sync_from_ib(store)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_authenticated_returns_none(self, store: LimitOrderStore) -> None:
+        """When Gateway is running but not authenticated, should return None"""
+        with patch("ib_sec_mcp.storage.order_sync.CPClient", autospec=True) as mock_cls:
+            mock_ctx = AsyncMock()
+            mock_ctx.check_auth_status.return_value = CPAuthStatus(
+                authenticated=False, connected=True
+            )
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await try_sync_from_ib(store)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_successful_sync(self, store: LimitOrderStore) -> None:
+        """When Gateway is running and authenticated, should perform sync"""
+        with patch("ib_sec_mcp.storage.order_sync.CPClient", autospec=True) as mock_cls:
+            mock_ctx = AsyncMock()
+            mock_ctx.check_auth_status.return_value = CPAuthStatus(
+                authenticated=True, connected=True
+            )
+            mock_ctx.get_orders.return_value = [
+                _make_ib_order(symbol="CSPX", price="700.00", status=CPOrderStatus.SUBMITTED)
+            ]
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_ctx)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await try_sync_from_ib(store)
+
+        assert result is not None
+        assert result.added == 1

--- a/tests/storage/test_order_sync.py
+++ b/tests/storage/test_order_sync.py
@@ -148,6 +148,28 @@ class TestSyncNewOrders:
         assert history[0]["status"] == "FILLED"
         assert history[0]["filled_price"] == Decimal("695.50")
 
+    @pytest.mark.asyncio
+    async def test_new_filled_order_fallback_to_limit_price(
+        self, mock_cp_client: AsyncMock, store: LimitOrderStore
+    ) -> None:
+        """New filled order with avg_price=0 should use limit_price as filled_price"""
+        mock_cp_client.get_orders.return_value = [
+            _make_ib_order(
+                symbol="CSPX",
+                price="700.00",
+                status=CPOrderStatus.FILLED,
+                avg_price="0",
+            )
+        ]
+
+        result = await sync_orders_from_ib(mock_cp_client, store)
+
+        assert result.added == 1
+        history = store.get_order_history(symbol="CSPX")
+        assert len(history) == 1
+        assert history[0]["status"] == "FILLED"
+        assert history[0]["filled_price"] == Decimal("700.00")
+
 
 # ---------------------------------------------------------------------------
 # Tests: sync_orders_from_ib — filled orders


### PR DESCRIPTION
## Summary

- Add `ib_sec_mcp/storage/order_sync.py` with IB → local DB sync logic
- Add `sync_limit_orders` MCP tool for manual sync trigger
- Matching by `symbol + limit_price + order_type` with IB as source of truth
- Graceful handling when Gateway is not running (skip, no error)

## Changes

### New Files
- `ib_sec_mcp/storage/order_sync.py` — Core sync logic
  - `sync_orders_from_ib()` — New/filled/cancelled order sync
  - `sync_orders_to_ib()` — Phase 2 stub (NotImplementedError)
  - `try_sync_from_ib()` — Gateway-safe wrapper for automated sync
- `tests/storage/test_order_sync.py` — 21 unit tests for sync logic

### Modified Files
- `ib_sec_mcp/mcp/tools/limit_orders.py` — Added `sync_limit_orders` tool
- `tests/mcp/test_limit_orders.py` — Added 3 MCP tool tests
- `tests/mcp/test_server.py` — Added `sync_limit_orders` to EXPECTED_TOOLS

## Test Plan

- [x] New IB order → sync → added to local DB
- [x] IB filled → sync → DB status FILLED with filled_price
- [x] IB cancelled → sync → DB status CANCELLED
- [x] Gateway not running → graceful skip (returns None)
- [x] Existing manual orders unaffected
- [x] Matching by side (BUY vs SELL at same price/symbol)
- [x] Already-filled orders in DB skipped
- [x] API failure → error in result, no crash
- [x] MCP tool: gateway unavailable → skipped status
- [x] MCP tool: successful sync → completed with counts
- [x] Phase 2 stub raises NotImplementedError
- [ ] [manual] Integration test with Paper account

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)