### PR TITLE
feat(orders): add order placement and management via Client Portal API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,13 @@ TOKEN=your_token_here
 # IB_GATEWAY_URL=https://localhost:5000
 # IB_GATEWAY_VERIFY_SSL=false
 
+# Order Management Safety Settings
+# IB_ORDER_DRY_RUN=1              # Dry-run mode (default: ON, set to 0 to enable live orders)
+# IB_READ_ONLY=0                  # Read-only mode (set to 1 to disable all order tools)
+# IB_MAX_ORDER_AMOUNT_USD=50000   # Per-order amount limit in USD (default: $50,000)
+# IB_DAILY_ORDER_LIMIT_USD=200000 # Daily total order amount limit in USD (default: $200,000)
+# IB_ORDER_LOG_PATH=data/processed/order_log.jsonl  # Order log file path
+
 # ==========================================
 # How to get your credentials:
 # ==========================================

--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -300,20 +300,7 @@ class CPClient:
             json=payload,
         )
 
-        # IB may return reply questions that need confirmation
-        replies = data if isinstance(data, list) else [data]
-        result: list[CPOrderReply] = []
-
-        for reply in replies:
-            parsed = CPOrderReply.model_validate(reply)
-            # If reply has an ID but no order_id, it needs confirmation
-            if parsed.reply_id and not parsed.order_id:
-                confirmed = await self._confirm_order_reply(parsed.reply_id)
-                result.extend(confirmed)
-            else:
-                result.append(parsed)
-
-        return result
+        return await self._parse_order_replies(data)
 
     async def modify_order(
         self,
@@ -346,9 +333,9 @@ class CPClient:
 
         payload: dict[str, object] = {}
         if quantity is not None:
-            payload["quantity"] = float(quantity)
+            payload["quantity"] = str(quantity)
         if limit_price is not None:
-            payload["price"] = float(limit_price)
+            payload["price"] = str(limit_price)
 
         data = await self._request(
             "POST",
@@ -356,16 +343,7 @@ class CPClient:
             json=payload,
         )
 
-        replies = data if isinstance(data, list) else [data]
-        result: list[CPOrderReply] = []
-        for reply in replies:
-            parsed = CPOrderReply.model_validate(reply)
-            if parsed.reply_id and not parsed.order_id:
-                confirmed = await self._confirm_order_reply(parsed.reply_id)
-                result.extend(confirmed)
-            else:
-                result.append(parsed)
-        return result
+        return await self._parse_order_replies(data)
 
     async def cancel_order(self, account_id: str, order_id: int) -> dict[str, object]:
         """
@@ -392,6 +370,34 @@ class CPClient:
             f"/v1/api/iserver/account/{account_id}/order/{order_id}",
         )
         return data
+
+    async def _parse_order_replies(
+        self,
+        data: dict | list,  # type: ignore[type-arg]
+    ) -> list[CPOrderReply]:
+        """Parse and auto-confirm IB order replies.
+
+        IB may return reply questions that need confirmation via a 2-step flow.
+        This method handles both direct responses and confirmation-required replies.
+
+        Args:
+            data: Raw API response (dict or list)
+
+        Returns:
+            List of CPOrderReply after processing/confirmation
+        """
+        replies = data if isinstance(data, list) else [data]
+        result: list[CPOrderReply] = []
+
+        for reply in replies:
+            parsed = CPOrderReply.model_validate(reply)
+            if parsed.reply_id and not parsed.order_id:
+                confirmed = await self._confirm_order_reply(parsed.reply_id)
+                result.extend(confirmed)
+            else:
+                result.append(parsed)
+
+        return result
 
     async def _confirm_order_reply(self, reply_id: str) -> list[CPOrderReply]:
         """

--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -8,6 +8,7 @@ Requires IB Gateway running locally with HTTPS enabled.
 
 import asyncio
 import os
+from decimal import Decimal
 
 import httpx
 
@@ -15,6 +16,8 @@ from ib_sec_mcp.api.cp_models import (
     CPAccountBalance,
     CPAuthStatus,
     CPOrder,
+    CPOrderReply,
+    CPOrderRequest,
     CPPosition,
 )
 from ib_sec_mcp.utils.logger import get_logger, mask_sensitive
@@ -261,6 +264,153 @@ class CPClient:
         if isinstance(data, list):
             return [CPPosition.model_validate(p) for p in data]
         return []
+
+    async def place_order(
+        self,
+        order: CPOrderRequest,
+    ) -> list[CPOrderReply]:
+        """
+        Place an order via Client Portal Gateway
+
+        IB uses a 2-step process: submit order, then confirm replies.
+
+        Args:
+            order: Order request details
+
+        Returns:
+            List of CPOrderReply with order status
+
+        Raises:
+            CPClientError: If order placement fails
+        """
+        await self._ensure_authenticated()
+        account_id = order.account_id
+        logger.info(
+            "Placing %s order for account %s: %s qty %s",
+            order.order_type.value,
+            mask_sensitive(account_id, show_chars=3),
+            order.side.value,
+            order.quantity,
+        )
+
+        payload = {"orders": [order.to_api_dict()]}
+        data = await self._request(
+            "POST",
+            f"/v1/api/iserver/account/{account_id}/orders",
+            json=payload,
+        )
+
+        # IB may return reply questions that need confirmation
+        replies = data if isinstance(data, list) else [data]
+        result: list[CPOrderReply] = []
+
+        for reply in replies:
+            parsed = CPOrderReply.model_validate(reply)
+            # If reply has an ID but no order_id, it needs confirmation
+            if parsed.reply_id and not parsed.order_id:
+                confirmed = await self._confirm_order_reply(parsed.reply_id)
+                result.extend(confirmed)
+            else:
+                result.append(parsed)
+
+        return result
+
+    async def modify_order(
+        self,
+        account_id: str,
+        order_id: int,
+        quantity: Decimal | None = None,
+        limit_price: Decimal | None = None,
+    ) -> list[CPOrderReply]:
+        """
+        Modify an existing order
+
+        Args:
+            account_id: IB account ID
+            order_id: Order ID to modify
+            quantity: New quantity (optional)
+            limit_price: New limit price (optional)
+
+        Returns:
+            List of CPOrderReply with modification status
+
+        Raises:
+            CPClientError: If modification fails
+        """
+        await self._ensure_authenticated()
+        logger.info(
+            "Modifying order %d for account %s",
+            order_id,
+            mask_sensitive(account_id, show_chars=3),
+        )
+
+        payload: dict[str, object] = {}
+        if quantity is not None:
+            payload["quantity"] = float(quantity)
+        if limit_price is not None:
+            payload["price"] = float(limit_price)
+
+        data = await self._request(
+            "POST",
+            f"/v1/api/iserver/account/{account_id}/order/{order_id}",
+            json=payload,
+        )
+
+        replies = data if isinstance(data, list) else [data]
+        result: list[CPOrderReply] = []
+        for reply in replies:
+            parsed = CPOrderReply.model_validate(reply)
+            if parsed.reply_id and not parsed.order_id:
+                confirmed = await self._confirm_order_reply(parsed.reply_id)
+                result.extend(confirmed)
+            else:
+                result.append(parsed)
+        return result
+
+    async def cancel_order(self, account_id: str, order_id: int) -> dict[str, object]:
+        """
+        Cancel an existing order
+
+        Args:
+            account_id: IB account ID
+            order_id: Order ID to cancel
+
+        Returns:
+            Cancellation response dict
+
+        Raises:
+            CPClientError: If cancellation fails
+        """
+        await self._ensure_authenticated()
+        logger.info(
+            "Cancelling order %d for account %s",
+            order_id,
+            mask_sensitive(account_id, show_chars=3),
+        )
+        data = await self._request(
+            "DELETE",
+            f"/v1/api/iserver/account/{account_id}/order/{order_id}",
+        )
+        return data
+
+    async def _confirm_order_reply(self, reply_id: str) -> list[CPOrderReply]:
+        """
+        Confirm an order reply (IB 2-step confirmation)
+
+        Args:
+            reply_id: Reply ID to confirm
+
+        Returns:
+            List of CPOrderReply after confirmation
+        """
+        logger.debug("Confirming order reply %s", reply_id)
+        data = await self._request(
+            "POST",
+            f"/v1/api/iserver/reply/{reply_id}",
+            json={"confirmed": True},
+        )
+        replies = data if isinstance(data, list) else [data]
+        return [CPOrderReply.model_validate(r) for r in replies]
 
     async def _ensure_authenticated(self) -> None:
         """

--- a/ib_sec_mcp/api/cp_models.py
+++ b/ib_sec_mcp/api/cp_models.py
@@ -128,12 +128,12 @@ class CPOrderRequest(BaseModel):
             "acctId": self.account_id,
             "conid": self.contract_id,
             "side": self.side.value,
-            "quantity": float(self.quantity),
+            "quantity": str(self.quantity),
             "orderType": self.order_type.value,
             "tif": self.tif,
         }
         if self.price is not None:
-            d["price"] = float(self.price)
+            d["price"] = str(self.price)
         return d
 
 

--- a/ib_sec_mcp/api/cp_models.py
+++ b/ib_sec_mcp/api/cp_models.py
@@ -98,3 +98,53 @@ class CPPosition(BaseModel):
         description="Unrealized P&L",
     )
     currency: str = Field("USD", description="Currency")
+
+
+class CPOrderType(StrEnum):
+    """Order type enumeration"""
+
+    MARKET = "MKT"
+    LIMIT = "LMT"
+    STOP = "STP"
+    STOP_LIMIT = "STP_LMT"
+
+
+class CPOrderRequest(BaseModel):
+    """Order placement request for Client Portal Gateway"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    account_id: str = Field(..., alias="acctId", description="Account ID")
+    contract_id: int = Field(..., alias="conid", description="Contract ID")
+    side: CPOrderSide = Field(..., description="Order side (BUY/SELL)")
+    quantity: Decimal = Field(..., description="Order quantity")
+    order_type: CPOrderType = Field(..., alias="orderType", description="Order type")
+    price: Decimal | None = Field(None, description="Limit price (required for LMT/STP_LMT)")
+    tif: str = Field("GTC", description="Time in force (GTC, DAY, IOC)")
+
+    def to_api_dict(self) -> dict[str, object]:
+        """Convert to IB CP API request format."""
+        d: dict[str, object] = {
+            "acctId": self.account_id,
+            "conid": self.contract_id,
+            "side": self.side.value,
+            "quantity": float(self.quantity),
+            "orderType": self.order_type.value,
+            "tif": self.tif,
+        }
+        if self.price is not None:
+            d["price"] = float(self.price)
+        return d
+
+
+class CPOrderReply(BaseModel):
+    """Order reply from Client Portal Gateway (confirmation step)"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    order_id: str | None = Field(None, alias="order_id", description="Order ID after placement")
+    order_status: str | None = Field(
+        None, alias="order_status", description="Order status after placement"
+    )
+    message: list[str] | None = Field(None, description="Confirmation messages")
+    reply_id: str | None = Field(None, alias="id", description="Reply ID for confirmation")

--- a/ib_sec_mcp/mcp/tools/__init__.py
+++ b/ib_sec_mcp/mcp/tools/__init__.py
@@ -21,6 +21,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from ib_sec_mcp.mcp.tools.live_trading import register_live_trading_tools
     from ib_sec_mcp.mcp.tools.market_comparison import register_market_comparison_tools
     from ib_sec_mcp.mcp.tools.options import register_options_tools
+    from ib_sec_mcp.mcp.tools.order_management import register_order_management_tools
     from ib_sec_mcp.mcp.tools.portfolio_analytics import (
         register_portfolio_analytics_tools,
     )
@@ -53,6 +54,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_sector_fx_tools(mcp)  # Add sector allocation and FX exposure tools
     register_limit_order_tools(mcp)  # Add limit order management tools
     register_live_trading_tools(mcp)  # Add live trading tools via CP Gateway
+    register_order_management_tools(mcp)  # Add order management tools (place/modify/cancel)
     register_daily_monitor_tools(mcp)  # Add daily monitor tools
 
 

--- a/ib_sec_mcp/mcp/tools/order_management.py
+++ b/ib_sec_mcp/mcp/tools/order_management.py
@@ -1,0 +1,781 @@
+"""Order placement and management MCP tools with safety mechanisms
+
+Provides order placement, modification, and cancellation via IB Client Portal
+Gateway API with multiple safety layers:
+- Dry-run mode (default ON)
+- Per-order amount limit
+- Daily order amount limit
+- Read-only mode
+- Full order logging with account masking
+"""
+
+import json
+import os
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from ib_sec_mcp.api.cp_client import (
+    CPAuthenticationError,
+    CPClient,
+    CPClientError,
+    CPConnectionError,
+)
+from ib_sec_mcp.api.cp_models import (
+    CPOrderReply,
+    CPOrderRequest,
+    CPOrderSide,
+    CPOrderType,
+)
+from ib_sec_mcp.utils.logger import mask_sensitive
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GATEWAY_NOT_RUNNING_MSG = (
+    "IB Client Portal Gateway is not running. Start the gateway and login at https://localhost:5000"
+)
+
+SESSION_EXPIRED_MSG = (
+    "IB Client Portal session has expired. Please re-authenticate at https://localhost:5000"
+)
+
+READ_ONLY_MSG = (
+    "Order management is disabled. IB_READ_ONLY=1 is set. "
+    "Unset IB_READ_ONLY to enable order placement."
+)
+
+DEFAULT_MAX_ORDER_AMOUNT_USD = Decimal("50000")
+DEFAULT_DAILY_ORDER_LIMIT_USD = Decimal("200000")
+DEFAULT_ORDER_LOG_PATH = Path("data/processed/order_log.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Safety helpers (module-level for testability)
+# ---------------------------------------------------------------------------
+
+
+def is_read_only() -> bool:
+    """Check if read-only mode is enabled via IB_READ_ONLY env var."""
+    return os.environ.get("IB_READ_ONLY", "0") in ("1", "true", "yes")
+
+
+def is_dry_run() -> bool:
+    """Check if dry-run mode is enabled via IB_ORDER_DRY_RUN env var.
+
+    Dry-run is ON by default — must be explicitly disabled.
+    """
+    val = os.environ.get("IB_ORDER_DRY_RUN", "1")
+    return val not in ("0", "false", "no")
+
+
+def get_max_order_amount() -> Decimal:
+    """Get per-order maximum amount from IB_MAX_ORDER_AMOUNT_USD env var."""
+    val = os.environ.get("IB_MAX_ORDER_AMOUNT_USD")
+    if val:
+        return Decimal(val)
+    return DEFAULT_MAX_ORDER_AMOUNT_USD
+
+
+def get_daily_order_limit() -> Decimal:
+    """Get daily order limit from IB_DAILY_ORDER_LIMIT_USD env var."""
+    val = os.environ.get("IB_DAILY_ORDER_LIMIT_USD")
+    if val:
+        return Decimal(val)
+    return DEFAULT_DAILY_ORDER_LIMIT_USD
+
+
+def get_order_log_path() -> Path:
+    """Get order log file path from IB_ORDER_LOG_PATH env var."""
+    val = os.environ.get("IB_ORDER_LOG_PATH")
+    if val:
+        return Path(val)
+    return DEFAULT_ORDER_LOG_PATH
+
+
+def estimate_order_amount(quantity: Decimal, price: Decimal | None) -> Decimal:
+    """Estimate order amount in USD for limit checks.
+
+    For market orders without a price, returns 0 (cannot validate).
+    """
+    if price is None or price == Decimal("0"):
+        return Decimal("0")
+    return abs(quantity * price)
+
+
+def check_order_amount_limit(quantity: Decimal, price: Decimal | None) -> str | None:
+    """Check if order exceeds per-order amount limit.
+
+    Returns error message if exceeded, None if within limits.
+    """
+    amount = estimate_order_amount(quantity, price)
+    if amount == Decimal("0"):
+        return None
+    max_amount = get_max_order_amount()
+    if amount > max_amount:
+        return (
+            f"Order amount ${amount:.2f} exceeds per-order limit "
+            f"${max_amount:.2f} (IB_MAX_ORDER_AMOUNT_USD)"
+        )
+    return None
+
+
+def get_daily_total(log_path: Path) -> Decimal:
+    """Calculate total order amount placed today from order log."""
+    if not log_path.exists():
+        return Decimal("0")
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    total = Decimal("0")
+
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Only count actual submissions (not dry runs, not cancels)
+            if record.get("dry_run", False):
+                continue
+            if record.get("action") != "place":
+                continue
+            if record.get("status") != "submitted":
+                continue
+            ts = record.get("timestamp", "")
+            if not ts.startswith(today):
+                continue
+            qty = Decimal(str(record.get("quantity", "0")))
+            price = Decimal(str(record.get("limit_price", "0")))
+            total += abs(qty * price)
+
+    return total
+
+
+def check_daily_limit(quantity: Decimal, price: Decimal | None, log_path: Path) -> str | None:
+    """Check if order would exceed daily limit.
+
+    Returns error message if exceeded, None if within limits.
+    """
+    amount = estimate_order_amount(quantity, price)
+    if amount == Decimal("0"):
+        return None
+    daily_total = get_daily_total(log_path)
+    daily_limit = get_daily_order_limit()
+    if daily_total + amount > daily_limit:
+        return (
+            f"Order would bring daily total to ${daily_total + amount:.2f}, "
+            f"exceeding daily limit ${daily_limit:.2f} (IB_DAILY_ORDER_LIMIT_USD). "
+            f"Today's total so far: ${daily_total:.2f}"
+        )
+    return None
+
+
+def mask_account_id(account_id: str) -> str:
+    """Mask account ID for logging, showing only last 4 chars."""
+    return mask_sensitive(account_id, show_chars=4)
+
+
+def write_order_log(
+    log_path: Path,
+    action: str,
+    account_id: str,
+    symbol: str,
+    side: str,
+    quantity: Decimal,
+    limit_price: Decimal | None,
+    order_id: str | int | None,
+    status: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Write an order log entry to JSONL file.
+
+    Returns the log record dict.
+    """
+    record = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "action": action,
+        "account_id": mask_account_id(account_id),
+        "symbol": symbol,
+        "side": side,
+        "quantity": str(quantity),
+        "limit_price": str(limit_price) if limit_price is not None else None,
+        "order_id": str(order_id) if order_id is not None else None,
+        "status": status,
+        "dry_run": dry_run,
+    }
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as f:
+        f.write(json.dumps(record, default=str) + "\n")
+
+    return record
+
+
+def _error_response(error: str) -> str:
+    """Return a JSON error response."""
+    return json.dumps({"error": error}, indent=2)
+
+
+def _reply_to_dict(reply: CPOrderReply) -> dict[str, Any]:
+    """Convert a CPOrderReply to a serializable dict."""
+    return {
+        "order_id": reply.order_id,
+        "order_status": reply.order_status,
+        "message": reply.message,
+    }
+
+
+def _validate_order_type(order_type: str) -> CPOrderType | None:
+    """Validate and convert order type string."""
+    try:
+        return CPOrderType(order_type.upper())
+    except ValueError:
+        return None
+
+
+def _validate_side(side: str) -> CPOrderSide | None:
+    """Validate and convert side string."""
+    try:
+        return CPOrderSide(side.upper())
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+def register_order_management_tools(mcp: FastMCP) -> None:
+    """Register order management tools via Client Portal Gateway"""
+
+    @mcp.tool
+    async def place_order(
+        account_id: str,
+        contract_id: int,
+        symbol: str,
+        side: str,
+        quantity: str,
+        order_type: str = "LMT",
+        limit_price: str | None = None,
+        tif: str = "GTC",
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Place an order via IB Client Portal Gateway
+
+        Places a buy or sell order with multiple safety mechanisms:
+        - Dry-run mode (default ON, set IB_ORDER_DRY_RUN=0 to disable)
+        - Per-order amount limit (IB_MAX_ORDER_AMOUNT_USD, default $50,000)
+        - Daily order limit (IB_DAILY_ORDER_LIMIT_USD, default $200,000)
+        - Read-only mode (IB_READ_ONLY=1 disables all order tools)
+        - Full order logging to data/processed/order_log.jsonl
+
+        Args:
+            account_id: IB account ID
+            contract_id: IB contract ID for the instrument
+            symbol: Trading symbol (e.g., "AAPL") for logging
+            side: Order side ("BUY" or "SELL")
+            quantity: Order quantity (as string for precision)
+            order_type: Order type ("LMT", "MKT", "STP", "STP_LMT")
+            limit_price: Limit price (required for LMT/STP_LMT orders)
+            tif: Time in force ("GTC", "DAY", "IOC")
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with order placement result
+        """
+        # Safety check: read-only mode
+        if is_read_only():
+            return _error_response(READ_ONLY_MSG)
+
+        # Validate inputs
+        side_enum = _validate_side(side)
+        if side_enum is None:
+            return _error_response(f"Invalid side: {side}. Use 'BUY' or 'SELL'")
+
+        order_type_enum = _validate_order_type(order_type)
+        if order_type_enum is None:
+            return _error_response(
+                f"Invalid order type: {order_type}. Use 'LMT', 'MKT', 'STP', or 'STP_LMT'"
+            )
+
+        qty = Decimal(quantity)
+        if qty <= Decimal("0"):
+            return _error_response("Quantity must be positive")
+
+        price = Decimal(limit_price) if limit_price else None
+
+        if order_type_enum in (CPOrderType.LIMIT, CPOrderType.STOP_LIMIT) and price is None:
+            return _error_response(f"Limit price is required for {order_type} orders")
+
+        # Safety check: per-order amount limit
+        amount_error = check_order_amount_limit(qty, price)
+        if amount_error:
+            return _error_response(amount_error)
+
+        # Safety check: daily limit
+        log_path = get_order_log_path()
+        daily_error = check_daily_limit(qty, price, log_path)
+        if daily_error:
+            return _error_response(daily_error)
+
+        dry_run = is_dry_run()
+
+        if dry_run:
+            if ctx:
+                await ctx.info(f"[DRY RUN] Would place {side} {quantity} {symbol}")
+            log_record = write_order_log(
+                log_path=log_path,
+                action="place",
+                account_id=account_id,
+                symbol=symbol,
+                side=side_enum.value,
+                quantity=qty,
+                limit_price=price,
+                order_id=None,
+                status="dry_run",
+                dry_run=True,
+            )
+            return json.dumps(
+                {
+                    "dry_run": True,
+                    "message": "[DRY RUN] Order not submitted. Set IB_ORDER_DRY_RUN=0 to enable.",
+                    "order_details": {
+                        "symbol": symbol,
+                        "side": side_enum.value,
+                        "quantity": str(qty),
+                        "order_type": order_type_enum.value,
+                        "limit_price": str(price) if price else None,
+                        "tif": tif,
+                    },
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        # Live order placement
+        if ctx:
+            await ctx.info(f"Placing {side} {quantity} {symbol} @ {limit_price or 'MKT'}")
+
+        try:
+            order_request = CPOrderRequest(
+                account_id=account_id,
+                contract_id=contract_id,
+                side=side_enum,
+                quantity=qty,
+                order_type=order_type_enum,
+                price=price,
+                tif=tif,
+            )
+
+            async with CPClient() as client:
+                replies = await client.place_order(order_request)
+
+            order_id = None
+            status = "submitted"
+            for reply in replies:
+                if reply.order_id:
+                    order_id = reply.order_id
+                if reply.order_status:
+                    status = reply.order_status
+
+            log_record = write_order_log(
+                log_path=log_path,
+                action="place",
+                account_id=account_id,
+                symbol=symbol,
+                side=side_enum.value,
+                quantity=qty,
+                limit_price=price,
+                order_id=order_id,
+                status=status,
+                dry_run=False,
+            )
+
+            return json.dumps(
+                {
+                    "dry_run": False,
+                    "status": status,
+                    "order_id": order_id,
+                    "replies": [_reply_to_dict(r) for r in replies],
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+        except CPClientError as e:
+            write_order_log(
+                log_path=log_path,
+                action="place",
+                account_id=account_id,
+                symbol=symbol,
+                side=side_enum.value,
+                quantity=qty,
+                limit_price=price,
+                order_id=None,
+                status="rejected",
+                dry_run=False,
+            )
+            return _error_response(f"Order placement failed: {e}")
+
+    @mcp.tool
+    async def modify_order(
+        account_id: str,
+        order_id: int,
+        symbol: str = "",
+        quantity: str | None = None,
+        limit_price: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Modify an existing order via IB Client Portal Gateway
+
+        Changes quantity and/or limit price of an active order.
+
+        Args:
+            account_id: IB account ID
+            order_id: Order ID to modify
+            symbol: Trading symbol (for logging)
+            quantity: New quantity (optional)
+            limit_price: New limit price (optional)
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with modification result
+        """
+        if is_read_only():
+            return _error_response(READ_ONLY_MSG)
+
+        if quantity is None and limit_price is None:
+            return _error_response("At least one of quantity or limit_price must be provided")
+
+        qty = Decimal(quantity) if quantity else None
+        price = Decimal(limit_price) if limit_price else None
+
+        if qty is not None and qty <= Decimal("0"):
+            return _error_response("Quantity must be positive")
+
+        # Safety check: per-order amount limit (if both qty and price available)
+        if qty and price:
+            amount_error = check_order_amount_limit(qty, price)
+            if amount_error:
+                return _error_response(amount_error)
+
+        log_path = get_order_log_path()
+        dry_run = is_dry_run()
+
+        if dry_run:
+            if ctx:
+                await ctx.info(f"[DRY RUN] Would modify order {order_id}")
+            log_record = write_order_log(
+                log_path=log_path,
+                action="modify",
+                account_id=account_id,
+                symbol=symbol,
+                side="",
+                quantity=qty or Decimal("0"),
+                limit_price=price,
+                order_id=order_id,
+                status="dry_run",
+                dry_run=True,
+            )
+            return json.dumps(
+                {
+                    "dry_run": True,
+                    "message": "[DRY RUN] Order not modified. Set IB_ORDER_DRY_RUN=0 to enable.",
+                    "order_id": order_id,
+                    "modifications": {
+                        "quantity": str(qty) if qty else None,
+                        "limit_price": str(price) if price else None,
+                    },
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        if ctx:
+            await ctx.info(f"Modifying order {order_id}")
+
+        try:
+            async with CPClient() as client:
+                replies = await client.modify_order(
+                    account_id=account_id,
+                    order_id=order_id,
+                    quantity=qty,
+                    limit_price=price,
+                )
+
+            status = "modified"
+            for reply in replies:
+                if reply.order_status:
+                    status = reply.order_status
+
+            log_record = write_order_log(
+                log_path=log_path,
+                action="modify",
+                account_id=account_id,
+                symbol=symbol,
+                side="",
+                quantity=qty or Decimal("0"),
+                limit_price=price,
+                order_id=order_id,
+                status=status,
+                dry_run=False,
+            )
+
+            return json.dumps(
+                {
+                    "dry_run": False,
+                    "status": status,
+                    "order_id": order_id,
+                    "replies": [_reply_to_dict(r) for r in replies],
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+        except CPClientError as e:
+            write_order_log(
+                log_path=log_path,
+                action="modify",
+                account_id=account_id,
+                symbol=symbol,
+                side="",
+                quantity=qty or Decimal("0"),
+                limit_price=price,
+                order_id=order_id,
+                status="rejected",
+                dry_run=False,
+            )
+            return _error_response(f"Order modification failed: {e}")
+
+    @mcp.tool
+    async def cancel_order(
+        account_id: str,
+        order_id: int,
+        symbol: str = "",
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Cancel an existing order via IB Client Portal Gateway
+
+        Args:
+            account_id: IB account ID
+            order_id: Order ID to cancel
+            symbol: Trading symbol (for logging)
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with cancellation result
+        """
+        if is_read_only():
+            return _error_response(READ_ONLY_MSG)
+
+        log_path = get_order_log_path()
+        dry_run = is_dry_run()
+
+        if dry_run:
+            if ctx:
+                await ctx.info(f"[DRY RUN] Would cancel order {order_id}")
+            log_record = write_order_log(
+                log_path=log_path,
+                action="cancel",
+                account_id=account_id,
+                symbol=symbol,
+                side="",
+                quantity=Decimal("0"),
+                limit_price=None,
+                order_id=order_id,
+                status="dry_run",
+                dry_run=True,
+            )
+            return json.dumps(
+                {
+                    "dry_run": True,
+                    "message": "[DRY RUN] Order not cancelled. Set IB_ORDER_DRY_RUN=0 to enable.",
+                    "order_id": order_id,
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        if ctx:
+            await ctx.info(f"Cancelling order {order_id}")
+
+        try:
+            async with CPClient() as client:
+                result = await client.cancel_order(account_id, order_id)
+
+            log_record = write_order_log(
+                log_path=log_path,
+                action="cancel",
+                account_id=account_id,
+                symbol=symbol,
+                side="",
+                quantity=Decimal("0"),
+                limit_price=None,
+                order_id=order_id,
+                status="cancelled",
+                dry_run=False,
+            )
+
+            return json.dumps(
+                {
+                    "dry_run": False,
+                    "status": "cancelled",
+                    "order_id": order_id,
+                    "api_response": result,
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+        except CPClientError as e:
+            write_order_log(
+                log_path=log_path,
+                action="cancel",
+                account_id=account_id,
+                symbol=symbol,
+                side="",
+                quantity=Decimal("0"),
+                limit_price=None,
+                order_id=order_id,
+                status="rejected",
+                dry_run=False,
+            )
+            return _error_response(f"Order cancellation failed: {e}")
+
+    @mcp.tool
+    async def cancel_all_orders(
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Cancel all open orders via IB Client Portal Gateway (emergency use)
+
+        Cancels ALL open orders across all accounts. Use with caution.
+
+        Args:
+            ctx: MCP context for logging
+
+        Returns:
+            JSON string with cancellation results
+        """
+        if is_read_only():
+            return _error_response(READ_ONLY_MSG)
+
+        log_path = get_order_log_path()
+        dry_run = is_dry_run()
+
+        if dry_run:
+            if ctx:
+                await ctx.info("[DRY RUN] Would cancel all open orders")
+            log_record = write_order_log(
+                log_path=log_path,
+                action="cancel_all",
+                account_id="ALL",
+                symbol="ALL",
+                side="",
+                quantity=Decimal("0"),
+                limit_price=None,
+                order_id=None,
+                status="dry_run",
+                dry_run=True,
+            )
+            return json.dumps(
+                {
+                    "dry_run": True,
+                    "message": "[DRY RUN] Orders not cancelled. Set IB_ORDER_DRY_RUN=0 to enable.",
+                    "log": log_record,
+                },
+                indent=2,
+            )
+
+        if ctx:
+            await ctx.info("Cancelling all open orders")
+
+        try:
+            async with CPClient() as client:
+                orders = await client.get_orders()
+                active_orders = [
+                    o
+                    for o in orders
+                    if o.status.value in ("Submitted", "PreSubmitted", "PendingSubmit")
+                ]
+
+                if not active_orders:
+                    return json.dumps(
+                        {"dry_run": False, "message": "No active orders to cancel"},
+                        indent=2,
+                    )
+
+                results: list[dict[str, Any]] = []
+                for order in active_orders:
+                    try:
+                        cancel_result = await client.cancel_order(order.account_id, order.order_id)
+                        write_order_log(
+                            log_path=log_path,
+                            action="cancel",
+                            account_id=order.account_id,
+                            symbol=order.symbol,
+                            side=order.side.value,
+                            quantity=order.quantity,
+                            limit_price=order.price,
+                            order_id=order.order_id,
+                            status="cancelled",
+                            dry_run=False,
+                        )
+                        results.append(
+                            {
+                                "order_id": order.order_id,
+                                "symbol": order.symbol,
+                                "status": "cancelled",
+                                "api_response": cancel_result,
+                            }
+                        )
+                    except CPClientError as e:
+                        results.append(
+                            {
+                                "order_id": order.order_id,
+                                "symbol": order.symbol,
+                                "status": "failed",
+                                "error": str(e),
+                            }
+                        )
+
+                return json.dumps(
+                    {
+                        "dry_run": False,
+                        "total_cancelled": sum(1 for r in results if r["status"] == "cancelled"),
+                        "total_failed": sum(1 for r in results if r["status"] == "failed"),
+                        "results": results,
+                    },
+                    indent=2,
+                )
+
+        except CPConnectionError:
+            return _error_response(GATEWAY_NOT_RUNNING_MSG)
+        except CPAuthenticationError:
+            return _error_response(SESSION_EXPIRED_MSG)
+
+
+__all__ = ["register_order_management_tools"]

--- a/ib_sec_mcp/mcp/tools/order_management.py
+++ b/ib_sec_mcp/mcp/tools/order_management.py
@@ -132,7 +132,7 @@ def get_daily_total(log_path: Path) -> Decimal:
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     total = Decimal("0")
 
-    with open(log_path) as f:
+    with open(log_path, encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -212,7 +212,7 @@ def write_order_log(
     }
 
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(log_path, "a") as f:
+    with open(log_path, "a", encoding="utf-8") as f:
         f.write(json.dumps(record, default=str) + "\n")
 
     return record
@@ -434,7 +434,7 @@ def register_order_management_tools(mcp: FastMCP) -> None:
     async def modify_order(
         account_id: str,
         order_id: int,
-        symbol: str = "",
+        symbol: str,
         quantity: str | None = None,
         limit_price: str | None = None,
         ctx: Context | None = None,
@@ -447,7 +447,7 @@ def register_order_management_tools(mcp: FastMCP) -> None:
         Args:
             account_id: IB account ID
             order_id: Order ID to modify
-            symbol: Trading symbol (for logging)
+            symbol: Trading symbol (for audit logging)
             quantity: New quantity (optional)
             limit_price: New limit price (optional)
             ctx: MCP context for logging
@@ -473,7 +473,12 @@ def register_order_management_tools(mcp: FastMCP) -> None:
             if amount_error:
                 return _error_response(amount_error)
 
+        # Safety check: daily limit (if both qty and price available)
         log_path = get_order_log_path()
+        if qty and price:
+            daily_error = check_daily_limit(qty, price, log_path)
+            if daily_error:
+                return _error_response(daily_error)
         dry_run = is_dry_run()
 
         if dry_run:
@@ -569,7 +574,7 @@ def register_order_management_tools(mcp: FastMCP) -> None:
     async def cancel_order(
         account_id: str,
         order_id: int,
-        symbol: str = "",
+        symbol: str,
         ctx: Context | None = None,
     ) -> str:
         """

--- a/ib_sec_mcp/mcp/tools/order_management.py
+++ b/ib_sec_mcp/mcp/tools/order_management.py
@@ -146,7 +146,7 @@ def get_daily_total(log_path: Path) -> Decimal:
                 continue
             if record.get("action") != "place":
                 continue
-            if record.get("status") != "submitted":
+            if record.get("status", "").lower() != "submitted":
                 continue
             ts = record.get("timestamp", "")
             if not ts.startswith(today):
@@ -307,11 +307,19 @@ def register_order_management_tools(mcp: FastMCP) -> None:
                 f"Invalid order type: {order_type}. Use 'LMT', 'MKT', 'STP', or 'STP_LMT'"
             )
 
-        qty = Decimal(quantity)
+        try:
+            qty = Decimal(quantity)
+        except Exception:
+            return _error_response(f"Invalid quantity: {quantity!r}. Must be a numeric value.")
         if qty <= Decimal("0"):
             return _error_response("Quantity must be positive")
 
-        price = Decimal(limit_price) if limit_price else None
+        try:
+            price = Decimal(limit_price) if limit_price else None
+        except Exception:
+            return _error_response(
+                f"Invalid limit_price: {limit_price!r}. Must be a numeric value."
+            )
 
         if order_type_enum in (CPOrderType.LIMIT, CPOrderType.STOP_LIMIT) and price is None:
             return _error_response(f"Limit price is required for {order_type} orders")
@@ -461,8 +469,16 @@ def register_order_management_tools(mcp: FastMCP) -> None:
         if quantity is None and limit_price is None:
             return _error_response("At least one of quantity or limit_price must be provided")
 
-        qty = Decimal(quantity) if quantity else None
-        price = Decimal(limit_price) if limit_price else None
+        try:
+            qty = Decimal(quantity) if quantity else None
+        except Exception:
+            return _error_response(f"Invalid quantity: {quantity!r}. Must be a numeric value.")
+        try:
+            price = Decimal(limit_price) if limit_price else None
+        except Exception:
+            return _error_response(
+                f"Invalid limit_price: {limit_price!r}. Must be a numeric value."
+            )
 
         if qty is not None and qty <= Decimal("0"):
             return _error_response("Quantity must be positive")

--- a/tests/mcp/test_order_management.py
+++ b/tests/mcp/test_order_management.py
@@ -1,0 +1,1020 @@
+"""Tests for order management MCP tools (place, modify, cancel)"""
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.api.cp_client import CPAuthenticationError, CPClientError, CPConnectionError
+from ib_sec_mcp.api.cp_models import (
+    CPOrder,
+    CPOrderReply,
+    CPOrderSide,
+    CPOrderStatus,
+)
+from ib_sec_mcp.mcp.tools.order_management import (
+    check_daily_limit,
+    check_order_amount_limit,
+    estimate_order_amount,
+    get_daily_total,
+    is_dry_run,
+    is_read_only,
+    mask_account_id,
+    register_order_management_tools,
+    write_order_log,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with order management tools registered."""
+    mcp = FastMCP("test")
+    register_order_management_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def order_log_path(tmp_path: Path) -> Path:
+    """Temporary order log path."""
+    return tmp_path / "order_log.jsonl"
+
+
+@pytest.fixture()
+def mock_order_reply() -> CPOrderReply:
+    """Sample order reply."""
+    return CPOrderReply(
+        order_id="12345",
+        order_status="Submitted",
+        message=["Order submitted"],
+    )
+
+
+@pytest.fixture()
+def mock_active_orders() -> list[CPOrder]:
+    """Sample active orders for cancel_all tests."""
+    return [
+        CPOrder(
+            orderId=1,
+            symbol="AAPL",
+            side=CPOrderSide.BUY,
+            totalSize=Decimal("10"),
+            price=Decimal("150.00"),
+            avgPrice=Decimal("0"),
+            status=CPOrderStatus.SUBMITTED,
+            orderType="LMT",
+            acct="U1234567",
+        ),
+        CPOrder(
+            orderId=2,
+            symbol="GLDM",
+            side=CPOrderSide.BUY,
+            totalSize=Decimal("25"),
+            price=Decimal("89.00"),
+            avgPrice=Decimal("0"),
+            status=CPOrderStatus.SUBMITTED,
+            orderType="LMT",
+            acct="U1234567",
+        ),
+    ]
+
+
+def _mock_cp_client(
+    orders: list[CPOrder] | None = None,
+    place_reply: list[CPOrderReply] | None = None,
+    modify_reply: list[CPOrderReply] | None = None,
+    cancel_result: dict | None = None,
+    accounts: list[str] | None = None,
+) -> MagicMock:
+    """Create a mock CPClient as async context manager."""
+    client = AsyncMock()
+    client.get_orders = AsyncMock(return_value=orders or [])
+    client.get_accounts = AsyncMock(return_value=accounts or ["U1234567"])
+    client.place_order = AsyncMock(return_value=place_reply or [])
+    client.modify_order = AsyncMock(return_value=modify_reply or [])
+    client.cancel_order = AsyncMock(return_value=cancel_result or {"msg": "cancelled"})
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Tests: Safety helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestIsReadOnly:
+    """Tests for is_read_only helper."""
+
+    def test_default_is_not_read_only(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            assert is_read_only() is False
+
+    def test_read_only_when_set_to_1(self) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "1"}):
+            assert is_read_only() is True
+
+    def test_read_only_when_set_to_true(self) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "true"}):
+            assert is_read_only() is True
+
+    def test_not_read_only_when_set_to_0(self) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "0"}):
+            assert is_read_only() is False
+
+
+class TestIsDryRun:
+    """Tests for is_dry_run helper."""
+
+    def test_default_is_dry_run(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            assert is_dry_run() is True
+
+    def test_dry_run_when_set_to_1(self) -> None:
+        with patch.dict("os.environ", {"IB_ORDER_DRY_RUN": "1"}):
+            assert is_dry_run() is True
+
+    def test_not_dry_run_when_set_to_0(self) -> None:
+        with patch.dict("os.environ", {"IB_ORDER_DRY_RUN": "0"}):
+            assert is_dry_run() is False
+
+    def test_not_dry_run_when_set_to_false(self) -> None:
+        with patch.dict("os.environ", {"IB_ORDER_DRY_RUN": "false"}):
+            assert is_dry_run() is False
+
+
+class TestEstimateOrderAmount:
+    """Tests for estimate_order_amount helper."""
+
+    def test_calculates_amount(self) -> None:
+        assert estimate_order_amount(Decimal("100"), Decimal("150.50")) == Decimal("15050.00")
+
+    def test_returns_zero_for_no_price(self) -> None:
+        assert estimate_order_amount(Decimal("100"), None) == Decimal("0")
+
+    def test_returns_zero_for_zero_price(self) -> None:
+        assert estimate_order_amount(Decimal("100"), Decimal("0")) == Decimal("0")
+
+    def test_uses_absolute_value(self) -> None:
+        assert estimate_order_amount(Decimal("-100"), Decimal("150")) == Decimal("15000")
+
+
+class TestCheckOrderAmountLimit:
+    """Tests for check_order_amount_limit helper."""
+
+    def test_within_limit(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = check_order_amount_limit(Decimal("10"), Decimal("100"))
+            assert result is None
+
+    def test_exceeds_limit(self) -> None:
+        with patch.dict("os.environ", {"IB_MAX_ORDER_AMOUNT_USD": "1000"}):
+            result = check_order_amount_limit(Decimal("100"), Decimal("20"))
+            assert result is not None
+            assert "exceeds" in result
+            assert "$2000" in result
+
+    def test_no_check_for_market_orders(self) -> None:
+        result = check_order_amount_limit(Decimal("100"), None)
+        assert result is None
+
+    def test_default_limit(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = check_order_amount_limit(Decimal("1"), Decimal("1"))
+            assert result is None  # $1 is within $50,000 default
+
+
+class TestMaskAccountId:
+    """Tests for mask_account_id helper."""
+
+    def test_masks_account_id(self) -> None:
+        masked = mask_account_id("U1234567")
+        assert "U1234567" not in masked
+        assert "4567" in masked
+
+    def test_short_account_id(self) -> None:
+        masked = mask_account_id("U123")
+        assert isinstance(masked, str)
+
+
+class TestWriteOrderLog:
+    """Tests for write_order_log helper."""
+
+    def test_writes_log_entry(self, order_log_path: Path) -> None:
+        record = write_order_log(
+            log_path=order_log_path,
+            action="place",
+            account_id="U1234567",
+            symbol="AAPL",
+            side="BUY",
+            quantity=Decimal("100"),
+            limit_price=Decimal("150.50"),
+            order_id="12345",
+            status="submitted",
+            dry_run=False,
+        )
+        assert record["action"] == "place"
+        assert record["symbol"] == "AAPL"
+        assert record["side"] == "BUY"
+        assert record["quantity"] == "100"
+        assert record["status"] == "submitted"
+        assert record["dry_run"] is False
+        # Account must be masked
+        assert "U1234567" not in record["account_id"]
+
+        # File must exist and contain valid JSONL
+        lines = order_log_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["symbol"] == "AAPL"
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "nested" / "dir" / "log.jsonl"
+        write_order_log(
+            log_path=log_path,
+            action="place",
+            account_id="U1234567",
+            symbol="GLDM",
+            side="BUY",
+            quantity=Decimal("25"),
+            limit_price=Decimal("89.00"),
+            order_id=None,
+            status="dry_run",
+            dry_run=True,
+        )
+        assert log_path.exists()
+
+    def test_appends_to_existing_log(self, order_log_path: Path) -> None:
+        for i in range(3):
+            write_order_log(
+                log_path=order_log_path,
+                action="place",
+                account_id="U1234567",
+                symbol=f"SYM{i}",
+                side="BUY",
+                quantity=Decimal("1"),
+                limit_price=Decimal("1"),
+                order_id=str(i),
+                status="submitted",
+                dry_run=False,
+            )
+        lines = order_log_path.read_text().strip().split("\n")
+        assert len(lines) == 3
+
+    def test_account_id_is_masked_in_log(self, order_log_path: Path) -> None:
+        write_order_log(
+            log_path=order_log_path,
+            action="place",
+            account_id="U9995070",
+            symbol="AAPL",
+            side="BUY",
+            quantity=Decimal("10"),
+            limit_price=Decimal("150"),
+            order_id=None,
+            status="dry_run",
+            dry_run=True,
+        )
+        content = order_log_path.read_text()
+        assert "U9995070" not in content
+        assert "5070" in content
+
+
+class TestGetDailyTotal:
+    """Tests for get_daily_total helper."""
+
+    def test_returns_zero_for_missing_file(self, tmp_path: Path) -> None:
+        assert get_daily_total(tmp_path / "nonexistent.jsonl") == Decimal("0")
+
+    def test_calculates_daily_total(self, order_log_path: Path) -> None:
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).isoformat()
+        entries = [
+            {
+                "timestamp": today,
+                "action": "place",
+                "quantity": "100",
+                "limit_price": "150",
+                "status": "submitted",
+                "dry_run": False,
+            },
+            {
+                "timestamp": today,
+                "action": "place",
+                "quantity": "50",
+                "limit_price": "200",
+                "status": "submitted",
+                "dry_run": False,
+            },
+        ]
+        with open(order_log_path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+        total = get_daily_total(order_log_path)
+        assert total == Decimal("25000")  # 100*150 + 50*200
+
+    def test_excludes_dry_runs(self, order_log_path: Path) -> None:
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).isoformat()
+        entry = {
+            "timestamp": today,
+            "action": "place",
+            "quantity": "100",
+            "limit_price": "150",
+            "status": "dry_run",
+            "dry_run": True,
+        }
+        with open(order_log_path, "w") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        assert get_daily_total(order_log_path) == Decimal("0")
+
+    def test_excludes_cancellations(self, order_log_path: Path) -> None:
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).isoformat()
+        entry = {
+            "timestamp": today,
+            "action": "cancel",
+            "quantity": "100",
+            "limit_price": "150",
+            "status": "submitted",
+            "dry_run": False,
+        }
+        with open(order_log_path, "w") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        assert get_daily_total(order_log_path) == Decimal("0")
+
+
+class TestCheckDailyLimit:
+    """Tests for check_daily_limit helper."""
+
+    def test_within_limit(self, order_log_path: Path) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            result = check_daily_limit(Decimal("10"), Decimal("100"), order_log_path)
+            assert result is None
+
+    def test_exceeds_limit(self, order_log_path: Path) -> None:
+        with patch.dict("os.environ", {"IB_DAILY_ORDER_LIMIT_USD": "1000"}):
+            result = check_daily_limit(Decimal("100"), Decimal("20"), order_log_path)
+            assert result is not None
+            assert "daily limit" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: place_order MCP tool
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceOrder:
+    """Tests for the place_order MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_mode_default(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        """Dry-run mode is ON by default - no API call made."""
+        with (
+            patch.dict(
+                "os.environ", {"IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")}, clear=True
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient") as mock_client_cls,
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="100",
+                order_type="LMT",
+                limit_price="150.50",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["dry_run"] is True
+        assert "DRY RUN" in data["message"]
+        assert data["order_details"]["symbol"] == "AAPL"
+        assert data["order_details"]["side"] == "BUY"
+        assert data["order_details"]["quantity"] == "100"
+        # CPClient should NOT have been used
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_logs_to_file(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        log_path = tmp_path / "log.jsonl"
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(log_path)},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="GLDM",
+                side="BUY",
+                quantity="25",
+                order_type="LMT",
+                limit_price="89.00",
+                ctx=None,
+            )
+
+        assert log_path.exists()
+        record = json.loads(log_path.read_text().strip())
+        assert record["action"] == "place"
+        assert record["dry_run"] is True
+        assert record["symbol"] == "GLDM"
+
+    @pytest.mark.asyncio
+    async def test_live_order_placement(
+        self, test_mcp: FastMCP, tmp_path: Path, mock_order_reply: CPOrderReply
+    ) -> None:
+        mock_cm = _mock_cp_client(place_reply=[mock_order_reply])
+        log_path = tmp_path / "log.jsonl"
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(log_path)},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="LMT",
+                limit_price="150.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["dry_run"] is False
+        assert data["status"] == "Submitted"
+        assert data["order_id"] == "12345"
+
+    @pytest.mark.asyncio
+    async def test_read_only_mode_blocks_placement(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "1"}):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="LMT",
+                limit_price="150.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "IB_READ_ONLY" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_amount_limit_exceeded(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "IB_MAX_ORDER_AMOUNT_USD": "1000",
+                "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl"),
+            },
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="100",
+                order_type="LMT",
+                limit_price="150.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "exceeds" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_exceeded(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        log_path = tmp_path / "log.jsonl"
+        # Pre-populate with orders near the limit
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).isoformat()
+        entry = {
+            "timestamp": today,
+            "action": "place",
+            "quantity": "100",
+            "limit_price": "1900",
+            "status": "submitted",
+            "dry_run": False,
+        }
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "w") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        with patch.dict(
+            "os.environ",
+            {
+                "IB_DAILY_ORDER_LIMIT_USD": "200000",
+                "IB_ORDER_LOG_PATH": str(log_path),
+            },
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="100",
+                order_type="LMT",
+                limit_price="200",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "daily limit" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_side(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="INVALID",
+                quantity="10",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "Invalid side" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_order_type(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="INVALID",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "Invalid order type" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_limit_price_required_for_lmt(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="LMT",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "Limit price is required" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_zero_quantity_rejected(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="0",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "positive" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_running(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPConnectionError("unreachable"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="LMT",
+                limit_price="150.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "not running" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_session_expired(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPAuthenticationError("expired"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="LMT",
+                limit_price="150.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "expired" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_api_error_logs_rejection(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        mock_cm = _mock_cp_client()
+        client = await mock_cm.__aenter__()
+        client.place_order = AsyncMock(side_effect=CPClientError("Insufficient funds"))
+        log_path = tmp_path / "log.jsonl"
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(log_path)},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10",
+                order_type="LMT",
+                limit_price="150.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        # Log should contain rejected entry
+        record = json.loads(log_path.read_text().strip())
+        assert record["status"] == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_decimal_precision_preserved(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        log_path = tmp_path / "log.jsonl"
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(log_path)},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("place_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                contract_id=265598,
+                symbol="AAPL",
+                side="BUY",
+                quantity="10.5",
+                order_type="LMT",
+                limit_price="150.75",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["order_details"]["quantity"] == "10.5"
+        assert data["order_details"]["limit_price"] == "150.75"
+        # Verify log record has Decimal strings
+        Decimal(data["log"]["quantity"])
+        Decimal(data["log"]["limit_price"])
+
+
+# ---------------------------------------------------------------------------
+# Tests: modify_order MCP tool
+# ---------------------------------------------------------------------------
+
+
+class TestModifyOrder:
+    """Tests for the modify_order MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_modify(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("modify_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                quantity="50",
+                limit_price="155.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["dry_run"] is True
+        assert data["order_id"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_live_modify(
+        self, test_mcp: FastMCP, tmp_path: Path, mock_order_reply: CPOrderReply
+    ) -> None:
+        mock_cm = _mock_cp_client(modify_reply=[mock_order_reply])
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("modify_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                limit_price="160.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["dry_run"] is False
+        assert data["status"] == "Submitted"
+
+    @pytest.mark.asyncio
+    async def test_read_only_blocks_modify(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "1"}):
+            tool = await test_mcp.get_tool("modify_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                quantity="50",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "IB_READ_ONLY" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_modifications_provided(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            tool = await test_mcp.get_tool("modify_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "At least one" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_amount_limit_on_modify(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "IB_MAX_ORDER_AMOUNT_USD": "1000",
+                "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl"),
+            },
+        ):
+            tool = await test_mcp.get_tool("modify_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                quantity="100",
+                limit_price="20.00",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "exceeds" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: cancel_order MCP tool
+# ---------------------------------------------------------------------------
+
+
+class TestCancelOrder:
+    """Tests for the cancel_order MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_cancel(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("cancel_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                symbol="AAPL",
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["dry_run"] is True
+        assert data["order_id"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_live_cancel(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        mock_cm = _mock_cp_client(cancel_result={"msg": "Order cancelled"})
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("cancel_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert data["dry_run"] is False
+        assert data["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_read_only_blocks_cancel(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "1"}):
+            tool = await test_mcp.get_tool("cancel_order")
+            result = await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                ctx=None,
+            )
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "IB_READ_ONLY" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_cancel_logs_entry(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        log_path = tmp_path / "log.jsonl"
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(log_path)},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("cancel_order")
+            await tool.fn(
+                account_id="U1234567",
+                order_id=12345,
+                symbol="AAPL",
+                ctx=None,
+            )
+
+        record = json.loads(log_path.read_text().strip())
+        assert record["action"] == "cancel"
+        assert "U1234567" not in record["account_id"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: cancel_all_orders MCP tool
+# ---------------------------------------------------------------------------
+
+
+class TestCancelAllOrders:
+    """Tests for the cancel_all_orders MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_cancel_all(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {"IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            clear=True,
+        ):
+            tool = await test_mcp.get_tool("cancel_all_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["dry_run"] is True
+        assert "DRY RUN" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_live_cancel_all(
+        self, test_mcp: FastMCP, tmp_path: Path, mock_active_orders: list[CPOrder]
+    ) -> None:
+        mock_cm = _mock_cp_client(
+            orders=mock_active_orders,
+            cancel_result={"msg": "cancelled"},
+        )
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("cancel_all_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert data["dry_run"] is False
+        assert data["total_cancelled"] == 2
+        assert data["total_failed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_active_orders(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        mock_cm = _mock_cp_client(orders=[])
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("cancel_all_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "No active orders" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_read_only_blocks_cancel_all(self, test_mcp: FastMCP) -> None:
+        with patch.dict("os.environ", {"IB_READ_ONLY": "1"}):
+            tool = await test_mcp.get_tool("cancel_all_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "IB_READ_ONLY" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_not_running(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(side_effect=CPConnectionError("unreachable"))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch.dict(
+                "os.environ",
+                {"IB_ORDER_DRY_RUN": "0", "IB_ORDER_LOG_PATH": str(tmp_path / "log.jsonl")},
+            ),
+            patch("ib_sec_mcp.mcp.tools.order_management.CPClient", return_value=mock_cm),
+        ):
+            tool = await test_mcp.get_tool("cancel_all_orders")
+            result = await tool.fn(ctx=None)
+            data = json.loads(result)
+
+        assert "error" in data
+        assert "not running" in data["error"]

--- a/tests/mcp/test_order_management.py
+++ b/tests/mcp/test_order_management.py
@@ -761,6 +761,7 @@ class TestModifyOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 quantity="50",
                 limit_price="155.00",
                 ctx=None,
@@ -786,6 +787,7 @@ class TestModifyOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 limit_price="160.00",
                 ctx=None,
             )
@@ -801,6 +803,7 @@ class TestModifyOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 quantity="50",
                 ctx=None,
             )
@@ -816,6 +819,7 @@ class TestModifyOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 ctx=None,
             )
             data = json.loads(result)
@@ -836,6 +840,7 @@ class TestModifyOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 quantity="100",
                 limit_price="20.00",
                 ctx=None,
@@ -887,6 +892,7 @@ class TestCancelOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 ctx=None,
             )
             data = json.loads(result)
@@ -901,6 +907,7 @@ class TestCancelOrder:
             result = await tool.fn(
                 account_id="U1234567",
                 order_id=12345,
+                symbol="AAPL",
                 ctx=None,
             )
             data = json.loads(result)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -95,6 +95,11 @@ EXPECTED_TOOLS = {
     "get_live_account_balance",
     "get_live_positions",
     "check_gateway_status",
+    # order_management
+    "place_order",
+    "modify_order",
+    "cancel_order",
+    "cancel_all_orders",
     # daily_monitor
     "sync_daily_snapshot",
     "get_sync_status",


### PR DESCRIPTION
## Summary

Implements order placement, modification, and cancellation via IB Client Portal Gateway API with multiple safety mechanisms (#97).

- **4 MCP tools**: `place_order`, `modify_order`, `cancel_order`, `cancel_all_orders`
- **6 safety mechanisms**: dry-run (default ON), per-order limit ($50K), daily limit ($200K), read-only mode, order logging, account masking
- **CP Client extensions**: 3 new methods + 2-step order confirmation flow
- **56 unit tests** covering all tools, safety helpers, and edge cases

## Changes

| File | Change |
|------|--------|
| `ib_sec_mcp/mcp/tools/order_management.py` | New module with 4 MCP tools + safety helpers |
| `ib_sec_mcp/api/cp_client.py` | Add `place_order`, `modify_order`, `cancel_order` methods |
| `ib_sec_mcp/api/cp_models.py` | Add `CPOrderRequest`, `CPOrderReply`, `CPOrderType` models |
| `ib_sec_mcp/mcp/tools/__init__.py` | Register order management tools |
| `tests/mcp/test_order_management.py` | 56 comprehensive tests |
| `tests/mcp/test_server.py` | Add 4 new tools to EXPECTED_TOOLS |
| `.env.example` | Document safety configuration env vars |

## Safety Design

| Mechanism | Default | Env Var |
|-----------|---------|---------|
| Dry-run mode | **ON** (no live orders) | `IB_ORDER_DRY_RUN=0` to disable |
| Per-order limit | $50,000 | `IB_MAX_ORDER_AMOUNT_USD` |
| Daily limit | $200,000 | `IB_DAILY_ORDER_LIMIT_USD` |
| Read-only mode | OFF | `IB_READ_ONLY=1` to enable |
| Order log | `data/processed/order_log.jsonl` | `IB_ORDER_LOG_PATH` |
| Account masking | Always on | N/A |

## Test plan

- [x] Dry-run mode prevents API calls (default behavior)
- [x] Amount limit exceeded returns error without placing order
- [x] Daily limit exceeded returns error without placing order
- [x] Read-only mode blocks all order tools
- [x] Account IDs masked in all log entries
- [x] All orders logged to JSONL file
- [x] Gateway connection errors handled gracefully
- [x] Session expiration handled gracefully
- [x] Invalid inputs (side, order type, quantity) rejected
- [x] Decimal precision preserved in all responses
- [x] Live order placement with 2-step confirmation
- [x] cancel_all cancels only active orders
- [ ] [manual] Paper Trading account: dry-run → live order test
- [ ] [manual] Verify `get_live_orders` → `get_pending_orders` consistency after placement

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)