### PR TITLE
test: add integration test suite for Client Portal API with Paper Trading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,13 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=ib_sec_mcp --cov-report=term-missing"
+addopts = "-v --cov=ib_sec_mcp --cov-report=term-missing --ignore=tests/integration"
 asyncio_mode = "auto"
+markers = [
+    "integration: Integration tests requiring external services",
+    "manual: Manual-only tests (not run in CI)",
+    "paper_trading: Tests requiring IB Paper Trading account and Gateway",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for IB Client Portal API with Paper Trading"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,87 @@
+"""Fixtures and skip conditions for Client Portal API integration tests
+
+These tests require:
+- IB Client Portal Gateway running locally (https://localhost:5000)
+- Authenticated session (browser login completed)
+- Paper Trading account
+"""
+
+import asyncio
+import contextlib
+import os
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from ib_sec_mcp.api.cp_client import CPClient, CPConnectionError
+
+
+def gateway_available() -> bool:
+    """Check if IB Client Portal Gateway is running and authenticated."""
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def _check() -> bool:
+                async with CPClient(max_retries=1) as client:
+                    status = await client.check_auth_status()
+                    return status.authenticated
+
+            return loop.run_until_complete(_check())
+        finally:
+            loop.close()
+    except (CPConnectionError, Exception):
+        return False
+
+
+requires_gateway = pytest.mark.skipif(
+    not gateway_available(),
+    reason="IB Client Portal Gateway not running or not authenticated",
+)
+
+# Apply markers to all tests in this directory
+pytestmark = [
+    requires_gateway,
+    pytest.mark.integration,
+    pytest.mark.paper_trading,
+    pytest.mark.manual,
+]
+
+
+@pytest.fixture()
+async def cp_client() -> AsyncGenerator[CPClient, None]:
+    """Provide an authenticated CPClient connected to the Paper Trading Gateway."""
+    async with CPClient() as client:
+        yield client
+
+
+@pytest.fixture()
+async def paper_account_id(cp_client: CPClient) -> str:
+    """Get the Paper Trading account ID.
+
+    Uses IB_PAPER_ACCOUNT_ID env var if set, otherwise fetches from Gateway.
+    """
+    env_id = os.environ.get("IB_PAPER_ACCOUNT_ID")
+    if env_id:
+        return env_id
+
+    accounts = await cp_client.get_accounts()
+    assert len(accounts) > 0, "No accounts found on Gateway"
+    return accounts[0]
+
+
+@pytest.fixture()
+async def cleanup_orders(
+    cp_client: CPClient, paper_account_id: str
+) -> AsyncGenerator[list[int], None]:
+    """Track and clean up test orders after each test.
+
+    Yields a list that tests can append order IDs to.
+    All tracked orders are cancelled in cleanup.
+    """
+    order_ids: list[int] = []
+    yield order_ids
+
+    for order_id in order_ids:
+        with contextlib.suppress(Exception):
+            await cp_client.cancel_order(paper_account_id, order_id)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
-from ib_sec_mcp.api.cp_client import CPClient, CPConnectionError
+from ib_sec_mcp.api.cp_client import CPClient, CPClientError
 
 
 def gateway_available() -> bool:
@@ -30,7 +30,7 @@ def gateway_available() -> bool:
             return loop.run_until_complete(_check())
         finally:
             loop.close()
-    except (CPConnectionError, Exception):
+    except CPClientError:
         return False
 
 
@@ -60,6 +60,7 @@ async def paper_account_id(cp_client: CPClient) -> str:
     """Get the Paper Trading account ID.
 
     Uses IB_PAPER_ACCOUNT_ID env var if set, otherwise fetches from Gateway.
+    Paper Trading accounts typically start with 'D' (demo).
     """
     env_id = os.environ.get("IB_PAPER_ACCOUNT_ID")
     if env_id:
@@ -67,6 +68,10 @@ async def paper_account_id(cp_client: CPClient) -> str:
 
     accounts = await cp_client.get_accounts()
     assert len(accounts) > 0, "No accounts found on Gateway"
+    # Prefer paper trading accounts (start with 'D' for demo)
+    paper_accounts = [a for a in accounts if a.startswith("D")]
+    if paper_accounts:
+        return paper_accounts[0]
     return accounts[0]
 
 

--- a/tests/integration/test_cp_connection.py
+++ b/tests/integration/test_cp_connection.py
@@ -1,0 +1,54 @@
+"""Integration tests for Client Portal Gateway connection and authentication"""
+
+import pytest
+
+from ib_sec_mcp.api.cp_client import CPClient, CPClientError, CPConnectionError
+
+
+class TestGatewayConnection:
+    """Test Gateway connectivity and session management"""
+
+    async def test_check_auth_status(self, cp_client: CPClient) -> None:
+        """Verify Gateway returns valid auth status."""
+        status = await cp_client.check_auth_status()
+        assert status.authenticated is True
+        assert status.connected is True
+
+    async def test_auth_status_fields(self, cp_client: CPClient) -> None:
+        """Verify auth status contains expected fields."""
+        status = await cp_client.check_auth_status()
+        assert isinstance(status.authenticated, bool)
+        assert isinstance(status.connected, bool)
+        assert isinstance(status.competing, bool)
+
+    async def test_reauthenticate(self, cp_client: CPClient) -> None:
+        """Verify reauthentication succeeds on an active session."""
+        result = await cp_client.reauthenticate()
+        assert result is True
+
+    async def test_get_accounts(self, cp_client: CPClient) -> None:
+        """Verify Gateway returns at least one account."""
+        accounts = await cp_client.get_accounts()
+        assert len(accounts) > 0
+        # Paper Trading account IDs typically start with 'D' or 'U'
+        for account_id in accounts:
+            assert isinstance(account_id, str)
+            assert len(account_id) > 0
+
+
+class TestGatewayNotRunning:
+    """Test behavior when Gateway is not available"""
+
+    @pytest.mark.skip(reason="Only run manually to verify graceful handling")
+    async def test_connection_error_on_wrong_port(self) -> None:
+        """Verify CPConnectionError when Gateway is unreachable."""
+        async with CPClient(
+            gateway_url="https://localhost:59999", max_retries=1, retry_delay=0.1
+        ) as client:
+            with pytest.raises(CPConnectionError):
+                await client.check_auth_status()
+
+    async def test_https_enforcement(self) -> None:
+        """Verify HTTP URLs are rejected."""
+        with pytest.raises(CPClientError, match="HTTP is not allowed"):
+            CPClient(gateway_url="http://localhost:5000")

--- a/tests/integration/test_cp_live_orders.py
+++ b/tests/integration/test_cp_live_orders.py
@@ -1,0 +1,70 @@
+"""Integration tests for live order retrieval from Client Portal Gateway"""
+
+from decimal import Decimal
+
+from ib_sec_mcp.api.cp_client import CPClient
+from ib_sec_mcp.api.cp_models import CPOrder, CPOrderSide, CPOrderStatus
+
+
+class TestLiveOrders:
+    """Test live order retrieval and filtering"""
+
+    async def test_get_orders_returns_list(self, cp_client: CPClient) -> None:
+        """Verify get_orders returns a list (may be empty if no orders)."""
+        orders = await cp_client.get_orders()
+        assert isinstance(orders, list)
+
+    async def test_order_model_fields(self, cp_client: CPClient) -> None:
+        """Verify order objects have correct field types when orders exist."""
+        orders = await cp_client.get_orders()
+        for order in orders:
+            assert isinstance(order, CPOrder)
+            assert isinstance(order.order_id, int)
+            assert isinstance(order.symbol, str)
+            assert isinstance(order.side, CPOrderSide)
+            assert isinstance(order.quantity, Decimal)
+            assert isinstance(order.status, CPOrderStatus)
+
+    async def test_filter_orders_by_status(self, cp_client: CPClient) -> None:
+        """Verify orders can be filtered by status in application code."""
+        orders = await cp_client.get_orders()
+        active_statuses = {
+            CPOrderStatus.SUBMITTED,
+            CPOrderStatus.PRE_SUBMITTED,
+            CPOrderStatus.PENDING_SUBMIT,
+        }
+        active_orders = [o for o in orders if o.status in active_statuses]
+        # All filtered orders should have active status
+        for order in active_orders:
+            assert order.status in active_statuses
+
+    async def test_filter_orders_by_symbol(self, cp_client: CPClient) -> None:
+        """Verify orders can be filtered by symbol in application code."""
+        orders = await cp_client.get_orders()
+        if orders:
+            target_symbol = orders[0].symbol
+            filtered = [o for o in orders if o.symbol == target_symbol]
+            assert len(filtered) >= 1
+            assert all(o.symbol == target_symbol for o in filtered)
+
+
+class TestAccountBalance:
+    """Test account balance retrieval"""
+
+    async def test_get_account_balance(self, cp_client: CPClient, paper_account_id: str) -> None:
+        """Verify balance retrieval returns valid Decimal values."""
+        balance = await cp_client.get_account_balance(paper_account_id)
+        assert balance.account_id == paper_account_id
+        assert isinstance(balance.net_liquidation, Decimal)
+        assert isinstance(balance.total_cash, Decimal)
+        assert isinstance(balance.buying_power, Decimal)
+        # Paper Trading accounts have initial capital
+        assert balance.net_liquidation > Decimal("0")
+
+    async def test_get_positions(self, cp_client: CPClient, paper_account_id: str) -> None:
+        """Verify positions retrieval returns a list."""
+        positions = await cp_client.get_positions(paper_account_id)
+        assert isinstance(positions, list)
+        for pos in positions:
+            assert isinstance(pos.position, Decimal)
+            assert isinstance(pos.symbol, str)

--- a/tests/integration/test_cp_order_flow.py
+++ b/tests/integration/test_cp_order_flow.py
@@ -1,0 +1,227 @@
+"""Integration tests for order lifecycle: place -> confirm -> modify -> cancel
+
+Uses Paper Trading account with limit orders far from market price
+to avoid accidental fills.
+"""
+
+import asyncio
+from decimal import Decimal
+
+import pytest
+
+from ib_sec_mcp.api.cp_client import CPClient
+from ib_sec_mcp.api.cp_models import (
+    CPOrderRequest,
+    CPOrderSide,
+    CPOrderStatus,
+    CPOrderType,
+)
+
+# AAPL contract ID on IB (well-known, stable)
+AAPL_CONID = 265598
+
+
+class TestOrderPlacement:
+    """Test order placement on Paper Trading account"""
+
+    async def test_place_limit_order(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+        cleanup_orders: list[int],
+    ) -> None:
+        """Place a limit buy order far below market price."""
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.00"),  # Far below market to avoid fill
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        assert len(replies) > 0
+
+        # Track for cleanup
+        cleanup_orders.extend(int(reply.order_id) for reply in replies if reply.order_id)
+
+    async def test_place_and_verify_order_appears(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+        cleanup_orders: list[int],
+    ) -> None:
+        """Place an order and verify it appears in the order list."""
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.01"),  # Unique price for identification
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+
+        order_ids = [int(r.order_id) for r in replies if r.order_id]
+        cleanup_orders.extend(order_ids)
+
+        # Wait briefly for order to propagate
+        await asyncio.sleep(1)
+
+        # Verify order appears in live orders
+        live_orders = await cp_client.get_orders()
+        live_order_ids = {o.order_id for o in live_orders}
+        assert any(oid in live_order_ids for oid in order_ids)
+
+
+class TestOrderModification:
+    """Test order modification on Paper Trading account"""
+
+    async def test_modify_order_price(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+        cleanup_orders: list[int],
+    ) -> None:
+        """Place an order, then modify its price."""
+        # Place initial order
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.02"),
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        order_id = int(replies[0].order_id) if replies[0].order_id else None
+        assert order_id is not None
+        cleanup_orders.append(order_id)
+
+        await asyncio.sleep(1)
+
+        # Modify price
+        mod_replies = await cp_client.modify_order(
+            account_id=paper_account_id,
+            order_id=order_id,
+            limit_price=Decimal("1.03"),
+        )
+        assert len(mod_replies) > 0
+
+    async def test_modify_order_quantity(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+        cleanup_orders: list[int],
+    ) -> None:
+        """Place an order, then modify its quantity."""
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.04"),
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        order_id = int(replies[0].order_id) if replies[0].order_id else None
+        assert order_id is not None
+        cleanup_orders.append(order_id)
+
+        await asyncio.sleep(1)
+
+        # Modify quantity
+        mod_replies = await cp_client.modify_order(
+            account_id=paper_account_id,
+            order_id=order_id,
+            quantity=Decimal("2"),
+        )
+        assert len(mod_replies) > 0
+
+
+class TestOrderCancellation:
+    """Test order cancellation on Paper Trading account"""
+
+    async def test_cancel_order(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+    ) -> None:
+        """Place and immediately cancel an order."""
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.05"),
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        order_id = int(replies[0].order_id) if replies[0].order_id else None
+        assert order_id is not None
+
+        await asyncio.sleep(1)
+
+        # Cancel
+        result = await cp_client.cancel_order(paper_account_id, order_id)
+        assert isinstance(result, dict)
+
+        # Verify order is cancelled or pending cancel
+        await asyncio.sleep(1)
+        live_orders = await cp_client.get_orders()
+        cancelled_statuses = {CPOrderStatus.CANCELLED, CPOrderStatus.PENDING_CANCEL}
+        for o in live_orders:
+            if o.order_id == order_id:
+                assert o.status in cancelled_statuses
+
+    @pytest.mark.skip(reason="Full lifecycle test — run manually for comprehensive validation")
+    async def test_full_order_lifecycle(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+    ) -> None:
+        """Full lifecycle: place -> verify -> modify -> verify -> cancel -> verify."""
+        # Place
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.10"),
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        order_id = int(replies[0].order_id) if replies[0].order_id else None
+        assert order_id is not None
+
+        await asyncio.sleep(2)
+
+        # Verify placed
+        orders = await cp_client.get_orders()
+        placed = [o for o in orders if o.order_id == order_id]
+        assert len(placed) == 1
+
+        # Modify
+        await cp_client.modify_order(
+            account_id=paper_account_id,
+            order_id=order_id,
+            limit_price=Decimal("1.11"),
+            quantity=Decimal("2"),
+        )
+        await asyncio.sleep(2)
+
+        # Cancel
+        await cp_client.cancel_order(paper_account_id, order_id)
+        await asyncio.sleep(2)
+
+        # Verify cancelled
+        orders = await cp_client.get_orders()
+        for o in orders:
+            if o.order_id == order_id:
+                assert o.status in {CPOrderStatus.CANCELLED, CPOrderStatus.PENDING_CANCEL}

--- a/tests/integration/test_cp_order_flow.py
+++ b/tests/integration/test_cp_order_flow.py
@@ -20,6 +20,25 @@ from ib_sec_mcp.api.cp_models import (
 # AAPL contract ID on IB (well-known, stable)
 AAPL_CONID = 265598
 
+# Polling configuration for order propagation
+POLL_INTERVAL = 0.5  # seconds between polls
+POLL_TIMEOUT = 10  # max seconds to wait
+
+
+async def poll_for_order(
+    cp_client: CPClient, order_ids: list[int], *, timeout: float = POLL_TIMEOUT
+) -> bool:
+    """Poll until order appears in live orders or timeout."""
+    elapsed = 0.0
+    while elapsed < timeout:
+        live_orders = await cp_client.get_orders()
+        live_order_ids = {o.order_id for o in live_orders}
+        if any(oid in live_order_ids for oid in order_ids):
+            return True
+        await asyncio.sleep(POLL_INTERVAL)
+        elapsed += POLL_INTERVAL
+    return False
+
 
 class TestOrderPlacement:
     """Test order placement on Paper Trading account"""
@@ -41,7 +60,7 @@ class TestOrderPlacement:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
-        assert len(replies) > 0
+        assert replies, "Order placement should return at least one reply"
 
         # Track for cleanup
         cleanup_orders.extend(int(reply.order_id) for reply in replies if reply.order_id)
@@ -63,17 +82,14 @@ class TestOrderPlacement:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
+        assert replies, "Order placement should return at least one reply"
 
         order_ids = [int(r.order_id) for r in replies if r.order_id]
         cleanup_orders.extend(order_ids)
 
-        # Wait briefly for order to propagate
-        await asyncio.sleep(1)
-
-        # Verify order appears in live orders
-        live_orders = await cp_client.get_orders()
-        live_order_ids = {o.order_id for o in live_orders}
-        assert any(oid in live_order_ids for oid in order_ids)
+        # Poll until order appears in live orders
+        found = await poll_for_order(cp_client, order_ids)
+        assert found, f"Order(s) {order_ids} not found in live orders within {POLL_TIMEOUT}s"
 
 
 class TestOrderModification:
@@ -97,11 +113,12 @@ class TestOrderModification:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
+        assert replies, "Order placement should return at least one reply"
         order_id = int(replies[0].order_id) if replies[0].order_id else None
         assert order_id is not None
         cleanup_orders.append(order_id)
 
-        await asyncio.sleep(1)
+        assert await poll_for_order(cp_client, [order_id])
 
         # Modify price
         mod_replies = await cp_client.modify_order(
@@ -128,11 +145,12 @@ class TestOrderModification:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
+        assert replies, "Order placement should return at least one reply"
         order_id = int(replies[0].order_id) if replies[0].order_id else None
         assert order_id is not None
         cleanup_orders.append(order_id)
 
-        await asyncio.sleep(1)
+        assert await poll_for_order(cp_client, [order_id])
 
         # Modify quantity
         mod_replies = await cp_client.modify_order(
@@ -162,22 +180,26 @@ class TestOrderCancellation:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
+        assert replies, "Order placement should return at least one reply"
         order_id = int(replies[0].order_id) if replies[0].order_id else None
         assert order_id is not None
 
-        await asyncio.sleep(1)
+        assert await poll_for_order(cp_client, [order_id])
 
         # Cancel
         result = await cp_client.cancel_order(paper_account_id, order_id)
         assert isinstance(result, dict)
 
-        # Verify order is cancelled or pending cancel
-        await asyncio.sleep(1)
-        live_orders = await cp_client.get_orders()
+        # Poll until order is cancelled
+        elapsed = 0.0
         cancelled_statuses = {CPOrderStatus.CANCELLED, CPOrderStatus.PENDING_CANCEL}
-        for o in live_orders:
-            if o.order_id == order_id:
-                assert o.status in cancelled_statuses
+        while elapsed < POLL_TIMEOUT:
+            live_orders = await cp_client.get_orders()
+            for o in live_orders:
+                if o.order_id == order_id and o.status in cancelled_statuses:
+                    return  # Test passed
+            await asyncio.sleep(POLL_INTERVAL)
+            elapsed += POLL_INTERVAL
 
     @pytest.mark.skip(reason="Full lifecycle test — run manually for comprehensive validation")
     async def test_full_order_lifecycle(
@@ -197,12 +219,12 @@ class TestOrderCancellation:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
+        assert replies, "Order placement should return at least one reply"
         order_id = int(replies[0].order_id) if replies[0].order_id else None
         assert order_id is not None
 
-        await asyncio.sleep(2)
-
         # Verify placed
+        assert await poll_for_order(cp_client, [order_id])
         orders = await cp_client.get_orders()
         placed = [o for o in orders if o.order_id == order_id]
         assert len(placed) == 1
@@ -214,14 +236,20 @@ class TestOrderCancellation:
             limit_price=Decimal("1.11"),
             quantity=Decimal("2"),
         )
-        await asyncio.sleep(2)
+        await asyncio.sleep(1)
 
         # Cancel
         await cp_client.cancel_order(paper_account_id, order_id)
-        await asyncio.sleep(2)
 
         # Verify cancelled
-        orders = await cp_client.get_orders()
-        for o in orders:
-            if o.order_id == order_id:
-                assert o.status in {CPOrderStatus.CANCELLED, CPOrderStatus.PENDING_CANCEL}
+        elapsed = 0.0
+        while elapsed < POLL_TIMEOUT:
+            orders = await cp_client.get_orders()
+            for o in orders:
+                if o.order_id == order_id and o.status in {
+                    CPOrderStatus.CANCELLED,
+                    CPOrderStatus.PENDING_CANCEL,
+                }:
+                    return
+            await asyncio.sleep(POLL_INTERVAL)
+            elapsed += POLL_INTERVAL

--- a/tests/integration/test_cp_order_sync.py
+++ b/tests/integration/test_cp_order_sync.py
@@ -69,9 +69,10 @@ class TestOrderSync:
             tif="DAY",
         )
         replies = await cp_client.place_order(order)
+        assert replies, "Order placement should return at least one reply"
         order_id = int(replies[0].order_id) if replies[0].order_id else None
-        if order_id:
-            cleanup_orders.append(order_id)
+        assert order_id is not None, "Order placement should return an order ID"
+        cleanup_orders.append(order_id)
 
         await asyncio.sleep(1)
 
@@ -121,6 +122,16 @@ class TestOrderSync:
         # Second sync — should detect cancellation
         result2 = await sync_orders_from_ib(cp_client, store)
         assert result2.errors == []
+
+        # Verify order status is CANCELLED in local DB
+        history = store.get_order_history()
+        synced = [
+            o for o in history if o["symbol"] == "AAPL" and o["limit_price"] == Decimal("1.07")
+        ]
+        assert len(synced) > 0, "Synced order should exist in local DB"
+        assert synced[0]["status"] == "CANCELLED", (
+            f"Order should be CANCELLED after sync, got {synced[0]['status']}"
+        )
 
 
 class TestTrySyncFromIB:

--- a/tests/integration/test_cp_order_sync.py
+++ b/tests/integration/test_cp_order_sync.py
@@ -1,0 +1,141 @@
+"""Integration tests for order sync between IB Gateway and local DB"""
+
+import asyncio
+from decimal import Decimal
+from pathlib import Path
+
+from ib_sec_mcp.api.cp_client import CPClient
+from ib_sec_mcp.api.cp_models import (
+    CPOrderRequest,
+    CPOrderSide,
+    CPOrderType,
+)
+from ib_sec_mcp.storage.limit_order_store import LimitOrderStore
+from ib_sec_mcp.storage.order_sync import sync_orders_from_ib, try_sync_from_ib
+
+AAPL_CONID = 265598
+
+
+class TestOrderSync:
+    """Test sync between IB live orders and local DB"""
+
+    async def test_sync_with_no_local_orders(
+        self,
+        cp_client: CPClient,
+        tmp_path: Path,
+    ) -> None:
+        """Sync should add IB orders to an empty local DB."""
+        store = LimitOrderStore(tmp_path / "test_sync.db")
+        result = await sync_orders_from_ib(cp_client, store)
+
+        assert result.errors == []
+        assert result.total_processed >= 0
+        # added + updated + skipped == total_processed
+        assert result.added + result.updated + result.skipped == result.total_processed
+
+    async def test_sync_idempotent(
+        self,
+        cp_client: CPClient,
+        tmp_path: Path,
+    ) -> None:
+        """Running sync twice should not duplicate orders."""
+        store = LimitOrderStore(tmp_path / "test_idempotent.db")
+
+        await sync_orders_from_ib(cp_client, store)
+        result2 = await sync_orders_from_ib(cp_client, store)
+
+        # Second sync should add 0 new orders
+        assert result2.added == 0
+        assert result2.errors == []
+
+    async def test_sync_after_placing_order(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+        cleanup_orders: list[int],
+        tmp_path: Path,
+    ) -> None:
+        """Place an order via API, then sync should capture it in local DB."""
+        store = LimitOrderStore(tmp_path / "test_place_sync.db")
+
+        # Place a test order
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.06"),
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        order_id = int(replies[0].order_id) if replies[0].order_id else None
+        if order_id:
+            cleanup_orders.append(order_id)
+
+        await asyncio.sleep(1)
+
+        # Sync
+        result = await sync_orders_from_ib(cp_client, store)
+        assert result.errors == []
+        assert result.added > 0
+
+        # Verify order is in local DB
+        history = store.get_order_history()
+        aapl_orders = [o for o in history if o["symbol"] == "AAPL"]
+        assert len(aapl_orders) > 0
+
+    async def test_sync_after_cancel_updates_status(
+        self,
+        cp_client: CPClient,
+        paper_account_id: str,
+        tmp_path: Path,
+    ) -> None:
+        """Cancel an order, then sync should update local DB status."""
+        store = LimitOrderStore(tmp_path / "test_cancel_sync.db")
+
+        # Place and then cancel
+        order = CPOrderRequest(
+            account_id=paper_account_id,
+            contract_id=AAPL_CONID,
+            side=CPOrderSide.BUY,
+            quantity=Decimal("1"),
+            order_type=CPOrderType.LIMIT,
+            price=Decimal("1.07"),
+            tif="DAY",
+        )
+        replies = await cp_client.place_order(order)
+        order_id = int(replies[0].order_id) if replies[0].order_id else None
+        assert order_id is not None
+
+        await asyncio.sleep(1)
+
+        # First sync — captures the active order
+        result1 = await sync_orders_from_ib(cp_client, store)
+        assert result1.errors == []
+
+        # Cancel the order
+        await cp_client.cancel_order(paper_account_id, order_id)
+        await asyncio.sleep(2)
+
+        # Second sync — should detect cancellation
+        result2 = await sync_orders_from_ib(cp_client, store)
+        assert result2.errors == []
+
+
+class TestTrySyncFromIB:
+    """Test the safe sync entry point"""
+
+    async def test_try_sync_with_running_gateway(self, tmp_path: Path) -> None:
+        """try_sync_from_ib should succeed when Gateway is running."""
+        store = LimitOrderStore(tmp_path / "test_try_sync.db")
+        result = await try_sync_from_ib(store)
+        # Should return a SyncResult, not None
+        assert result is not None
+        assert result.errors == []
+
+    async def test_try_sync_with_bad_url(self, tmp_path: Path) -> None:
+        """try_sync_from_ib should return None when Gateway is unreachable."""
+        store = LimitOrderStore(tmp_path / "test_bad_url.db")
+        result = await try_sync_from_ib(store, gateway_url="https://localhost:59999")
+        assert result is None


### PR DESCRIPTION
## Summary

- Add `tests/integration/` with 24 integration tests for the Client Portal API using Paper Trading account
- Tests cover connection, live orders, order lifecycle (place/modify/cancel), and DB sync
- All tests auto-skip when Gateway is not running — zero impact on CI/CD

## Changes

### New Files
- `tests/integration/__init__.py` — Package init
- `tests/integration/conftest.py` — `gateway_available()` skip condition + fixtures (`cp_client`, `paper_account_id`, `cleanup_orders`)
- `tests/integration/test_cp_connection.py` — Gateway auth, reauthentication, HTTPS enforcement (5 tests)
- `tests/integration/test_cp_live_orders.py` — Order listing, filtering, balance, positions (6 tests)
- `tests/integration/test_cp_order_flow.py` — Place → modify → cancel order lifecycle (6 tests)
- `tests/integration/test_cp_order_sync.py` — IB ↔ local DB sync verification (7 tests)

### Modified Files
- `pyproject.toml` — Register `integration`, `manual`, `paper_trading` markers + `--ignore=tests/integration` in `addopts`

## Test Plan

- [x] `uv run pytest tests/` runs 886 tests — integration tests fully ignored
- [x] `uv run pytest tests/integration/ --collect-only` collects 24 tests
- [x] `uv run pytest tests/integration/ -m paper_trading` correctly skips when Gateway not running
- [x] Ruff lint and format pass
- [ ] [manual] Run with live Gateway: `uv run pytest tests/integration/ -v`

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)