### PR TITLE
fix(api): paginate positions and preserve connection errors in CPClient

### DIFF
--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -275,6 +275,13 @@ class CPClient:
 
             all_positions.extend(CPPosition.model_validate(p) for p in data)
             page += 1
+        else:
+            logger.warning(
+                "Reached max_pages (%d) while fetching positions for account %s. "
+                "Data may be truncated.",
+                max_pages,
+                mask_sensitive(account_id, show_chars=3),
+            )
 
         if page > 1:
             logger.info(

--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -270,8 +270,17 @@ class CPClient:
         while page < max_pages:
             data = await self._request("GET", f"/v1/api/portfolio/{account_id}/positions/{page}")
 
-            if not isinstance(data, list) or len(data) == 0:
+            if isinstance(data, list) and len(data) == 0:
                 break
+
+            if not isinstance(data, list):
+                if page == 0:
+                    # First page returning non-list means no positions
+                    break
+                raise CPClientError(
+                    f"Unexpected response on positions page {page}: "
+                    f"expected list, got {type(data).__name__}"
+                )
 
             all_positions.extend(CPPosition.model_validate(p) for p in data)
             page += 1

--- a/ib_sec_mcp/api/cp_client.py
+++ b/ib_sec_mcp/api/cp_client.py
@@ -243,7 +243,10 @@ class CPClient:
 
     async def get_positions(self, account_id: str) -> list[CPPosition]:
         """
-        Get positions for an account
+        Get all positions for an account (handles pagination)
+
+        The IB API paginates positions (~30 per page). This method
+        fetches all pages until an empty response is returned.
 
         Args:
             account_id: IB account ID
@@ -259,11 +262,29 @@ class CPClient:
             "Fetching positions for account %s",
             mask_sensitive(account_id, show_chars=3),
         )
-        data = await self._request("GET", f"/v1/api/portfolio/{account_id}/positions/0")
 
-        if isinstance(data, list):
-            return [CPPosition.model_validate(p) for p in data]
-        return []
+        all_positions: list[CPPosition] = []
+        page = 0
+        max_pages = 100  # Safety limit to prevent infinite loops
+
+        while page < max_pages:
+            data = await self._request("GET", f"/v1/api/portfolio/{account_id}/positions/{page}")
+
+            if not isinstance(data, list) or len(data) == 0:
+                break
+
+            all_positions.extend(CPPosition.model_validate(p) for p in data)
+            page += 1
+
+        if page > 1:
+            logger.info(
+                "Fetched %d positions across %d pages for account %s",
+                len(all_positions),
+                page,
+                mask_sensitive(account_id, show_chars=3),
+            )
+
+        return all_positions
 
     async def place_order(
         self,
@@ -423,10 +444,13 @@ class CPClient:
         Ensure session is authenticated, reauthenticate if needed
 
         Raises:
+            CPConnectionError: If gateway is unreachable
             CPAuthenticationError: If authentication cannot be established
         """
         try:
             status = await self.check_auth_status()
+        except CPConnectionError:
+            raise
         except CPClientError as e:
             raise CPAuthenticationError(f"Cannot verify auth status: {e}") from e
 

--- a/tests/api/test_cp_client.py
+++ b/tests/api/test_cp_client.py
@@ -405,9 +405,12 @@ class TestCPClientPositions:
     async def test_get_positions(self, cp_client: CPClient) -> None:
         auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
         positions_response = make_async_mock_response(SAMPLE_POSITIONS)
+        empty_response = make_async_mock_response([])
 
         async with cp_client as client:
-            client._client.request = AsyncMock(side_effect=[auth_response, positions_response])
+            client._client.request = AsyncMock(
+                side_effect=[auth_response, positions_response, empty_response]
+            )
             positions = await client.get_positions("U1234567")
 
             assert len(positions) == 1
@@ -424,6 +427,52 @@ class TestCPClientPositions:
             client._client.request = AsyncMock(side_effect=[auth_response, empty_response])
             positions = await client.get_positions("U1234567")
             assert positions == []
+
+    @pytest.mark.asyncio
+    async def test_get_positions_paginated(self, cp_client: CPClient) -> None:
+        """Test that get_positions fetches all pages until empty response"""
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        page0_positions = [
+            {
+                "acctId": "U1234567",
+                "conid": 265598,
+                "symbol": "AAPL",
+                "position": "100",
+                "mktPrice": "175.50",
+                "mktValue": "17550.00",
+                "avgCost": "150.25",
+                "unrealizedPnl": "2525.00",
+                "currency": "USD",
+            }
+        ]
+        page1_positions = [
+            {
+                "acctId": "U1234567",
+                "conid": 272093,
+                "symbol": "MSFT",
+                "position": "50",
+                "mktPrice": "400.00",
+                "mktValue": "20000.00",
+                "avgCost": "350.00",
+                "unrealizedPnl": "2500.00",
+                "currency": "USD",
+            }
+        ]
+        page0_response = make_async_mock_response(page0_positions)
+        page1_response = make_async_mock_response(page1_positions)
+        empty_response = make_async_mock_response([])
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(
+                side_effect=[auth_response, page0_response, page1_response, empty_response]
+            )
+            positions = await client.get_positions("U1234567")
+
+            assert len(positions) == 2
+            assert positions[0].symbol == "AAPL"
+            assert positions[1].symbol == "MSFT"
+            # Verify all 3 pages were requested (page 0, 1, 2)
+            assert client._client.request.call_count == 4  # auth + 3 pages
 
 
 # ---------------------------------------------------------------------------
@@ -477,6 +526,16 @@ class TestCPClientConnection:
             client._client.request = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
             with pytest.raises(CPConnectionError, match="Cannot connect to gateway"):
                 await client._request("GET", "/test")
+
+    @pytest.mark.asyncio
+    async def test_ensure_authenticated_preserves_connection_error(
+        self, cp_client: CPClient
+    ) -> None:
+        """Test that CPConnectionError is not masked as CPAuthenticationError"""
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+            with pytest.raises(CPConnectionError, match="Cannot connect to gateway"):
+                await client._ensure_authenticated()
 
     @pytest.mark.asyncio
     async def test_context_manager(self, cp_client: CPClient) -> None:

--- a/tests/api/test_cp_client.py
+++ b/tests/api/test_cp_client.py
@@ -474,6 +474,36 @@ class TestCPClientPositions:
             # Verify all 3 pages were requested (page 0, 1, 2)
             assert client._client.request.call_count == 4  # auth + 3 pages
 
+    @pytest.mark.asyncio
+    async def test_get_positions_non_list_response_mid_pagination_raises(
+        self, cp_client: CPClient
+    ) -> None:
+        """Non-list response after page 0 should raise CPClientError"""
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        page0_response = make_async_mock_response(SAMPLE_POSITIONS)
+        # Simulate gateway returning a dict message on page 1
+        bad_response = make_async_mock_response({"message": "temporary error"})
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(
+                side_effect=[auth_response, page0_response, bad_response]
+            )
+            with pytest.raises(CPClientError, match="Unexpected response on positions page 1"):
+                await client.get_positions("U1234567")
+
+    @pytest.mark.asyncio
+    async def test_get_positions_non_list_first_page_returns_empty(
+        self, cp_client: CPClient
+    ) -> None:
+        """Non-list response on first page returns empty (no positions)"""
+        auth_response = make_async_mock_response(AUTH_AUTHENTICATED)
+        dict_response = make_async_mock_response({"message": "no data"})
+
+        async with cp_client as client:
+            client._client.request = AsyncMock(side_effect=[auth_response, dict_response])
+            positions = await client.get_positions("U1234567")
+            assert positions == []
+
 
 # ---------------------------------------------------------------------------
 # TestCPClientSecurity


### PR DESCRIPTION
## Summary

Addresses two unresolved review comments from PR #98 (chatgpt-codex-connector):

- **Pagination for `get_positions`**: Previously only fetched page 0 (`/positions/0`). IB paginates ~30 positions per page, so accounts with more holdings silently lost data. Now loops through all pages until empty response.
- **Connection error preservation**: `_ensure_authenticated` was catching `CPClientError` (base class) and re-raising as `CPAuthenticationError`, masking `CPConnectionError` when the gateway was down. Now `CPConnectionError` propagates correctly.

Closes #96

## Test plan

- [x] New test: `test_get_positions_paginated` — verifies multi-page fetching
- [x] New test: `test_ensure_authenticated_preserves_connection_error` — verifies `CPConnectionError` is not masked
- [x] All 34 existing tests pass
- [x] Lint (`ruff`) and type check (`mypy`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)