### PR TITLE
refactor(models): migrate Pydantic v1 Config/json_encoders to v2 ConfigDict (#118)

### DIFF
--- a/ib_sec_mcp/analyzers/sentiment/base.py
+++ b/ib_sec_mcp/analyzers/sentiment/base.py
@@ -90,13 +90,6 @@ class SentimentScore(BaseModel):
             raise ValueError(f"Confidence must be between 0.0 and 1.0, got {v}")
         return v
 
-    model_config = {
-        "json_encoders": {
-            Decimal: str,
-            datetime: lambda v: v.isoformat(),
-        }
-    }
-
 
 class BaseSentimentAnalyzer(ABC):
     """

--- a/ib_sec_mcp/api/models.py
+++ b/ib_sec_mcp/api/models.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class FlexQueryStatus(StrEnum):
@@ -43,14 +43,6 @@ class FlexStatement(BaseModel):
     when_generated: datetime = Field(..., description="Statement generation timestamp")
     raw_data: str = Field(..., description="Raw XML/CSV data")
 
-    class Config:
-        """Pydantic config"""
-
-        json_encoders = {
-            date: lambda v: v.isoformat(),
-            datetime: lambda v: v.isoformat(),
-        }
-
 
 class AccountInfo(BaseModel):
     """Account information section"""
@@ -73,10 +65,7 @@ class AccountInfo(BaseModel):
     country: str | None = Field(None, alias="Country")
     postal_code: str | None = Field(None, alias="PostalCode")
 
-    class Config:
-        """Pydantic config"""
-
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class CashSummary(BaseModel):
@@ -109,10 +98,7 @@ class CashSummary(BaseModel):
     ending_cash_sec: Decimal = Field(Decimal("0"), alias="EndingCashSec")
     ending_settled_cash: Decimal = Field(..., alias="EndingSettledCash")
 
-    class Config:
-        """Pydantic config"""
-
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class APICredentials(BaseModel):

--- a/ib_sec_mcp/models/account.py
+++ b/ib_sec_mcp/models/account.py
@@ -54,13 +54,6 @@ class CashBalance(BaseModel):
         """Net deposits/withdrawals"""
         return self.deposits - self.withdrawals
 
-    class Config:
-        """Pydantic config"""
-
-        json_encoders = {
-            Decimal: lambda v: str(v),
-        }
-
 
 class Account(BaseModel):
     """Account information and data"""
@@ -144,11 +137,3 @@ class Account(BaseModel):
             if balance.currency == currency:
                 return balance
         return None
-
-    class Config:
-        """Pydantic config"""
-
-        json_encoders = {
-            date: lambda v: v.isoformat(),
-            Decimal: lambda v: str(v),
-        }

--- a/ib_sec_mcp/models/portfolio.py
+++ b/ib_sec_mcp/models/portfolio.py
@@ -173,11 +173,3 @@ class Portfolio(BaseModel):
             from_date=from_date,
             to_date=to_date,
         )
-
-    class Config:
-        """Pydantic config"""
-
-        json_encoders = {
-            date: lambda v: v.isoformat(),
-            Decimal: lambda v: str(v),
-        }

--- a/ib_sec_mcp/models/position.py
+++ b/ib_sec_mcp/models/position.py
@@ -81,11 +81,3 @@ class Position(BaseModel):
     def is_bond(self) -> bool:
         """Check if position is a bond"""
         return self.asset_class == AssetClass.BOND
-
-    class Config:
-        """Pydantic config"""
-
-        json_encoders = {
-            date: lambda v: v.isoformat(),
-            Decimal: lambda v: str(v),
-        }

--- a/ib_sec_mcp/models/trade.py
+++ b/ib_sec_mcp/models/trade.py
@@ -97,12 +97,3 @@ class Trade(BaseModel):
         if self.gross_amount == 0:
             return Decimal("0")
         return abs(self.ib_commission) / self.gross_amount * 100
-
-    class Config:
-        """Pydantic config"""
-
-        json_encoders = {
-            date: lambda v: v.isoformat(),
-            datetime: lambda v: v.isoformat(),
-            Decimal: lambda v: str(v),
-        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,11 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --cov=ib_sec_mcp --cov-report=term-missing --ignore=tests/integration"
 asyncio_mode = "auto"
+filterwarnings = [
+    # Issue #118: gate Pydantic v1 deprecations (scoped to pydantic only, not
+    # unrelated third-party DeprecationWarnings) so reintroductions fail CI.
+    "error::pydantic.PydanticDeprecationWarning",
+]
 markers = [
     "integration: Integration tests requiring external services",
     "manual: Manual-only tests (not run in CI)",

--- a/tests/models/test_serialization.py
+++ b/tests/models/test_serialization.py
@@ -18,6 +18,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 import pytest
+from pydantic import PydanticDeprecationWarning
 
 from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
 from ib_sec_mcp.api.models import CashSummary, FlexStatement
@@ -164,7 +165,7 @@ class TestNoDeprecationWarnings:
         self, sample_account: Account, sample_trade: Trade, sample_position: Position
     ) -> None:
         with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
+            warnings.simplefilter("error", PydanticDeprecationWarning)
             sample_account.model_dump_json()
             sample_trade.model_dump_json()
             sample_position.model_dump_json()

--- a/tests/models/test_serialization.py
+++ b/tests/models/test_serialization.py
@@ -1,0 +1,171 @@
+"""Regression tests for Pydantic v2 JSON serialization (Issue #118).
+
+After migrating away from the deprecated ``class Config`` / ``json_encoders``
+pattern, these tests lock in the externally observable serialization behavior
+that MCP JSON output depends on:
+
+- ``Decimal`` values serialize to JSON **strings** (precision preserved,
+  including trailing zeros), never floats.
+- ``date`` / ``datetime`` values serialize to ISO 8601 strings.
+- Serialization emits no ``DeprecationWarning`` (e.g. ``PydanticDeprecatedSince20``).
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
+from ib_sec_mcp.api.models import CashSummary, FlexStatement
+from ib_sec_mcp.models.account import Account, CashBalance
+from ib_sec_mcp.models.position import Position
+from ib_sec_mcp.models.trade import AssetClass, BuySell, Trade
+
+
+@pytest.fixture
+def sample_trade() -> Trade:
+    return Trade(
+        account_id="U1234567",
+        trade_id="T001",
+        trade_date=date(2025, 1, 15),
+        settle_date=date(2025, 1, 17),
+        symbol="AAPL",
+        description="APPLE INC",
+        asset_class=AssetClass.STOCK,
+        buy_sell=BuySell.BUY,
+        quantity=Decimal("100"),
+        trade_price=Decimal("150.50"),
+        trade_money=Decimal("-15050.00"),
+        currency="USD",
+        fx_rate_to_base=Decimal("1.0"),
+        ib_commission=Decimal("-1.50"),
+        fifo_pnl_realized=Decimal("500.00"),
+        mtm_pnl=Decimal("200.00"),
+    )
+
+
+@pytest.fixture
+def sample_position() -> Position:
+    return Position(
+        account_id="U1234567",
+        symbol="AAPL",
+        asset_class=AssetClass.STOCK,
+        quantity=Decimal("100"),
+        mark_price=Decimal("150.00"),
+        position_value=Decimal("15000.00"),
+        average_cost=Decimal("120.00"),
+        cost_basis=Decimal("12000.00"),
+        unrealized_pnl=Decimal("3000.00"),
+        position_date=date(2025, 6, 30),
+    )
+
+
+@pytest.fixture
+def sample_account(sample_position: Position, sample_trade: Trade) -> Account:
+    return Account(
+        account_id="U1234567",
+        account_alias="Test Account",
+        from_date=date(2025, 1, 1),
+        to_date=date(2025, 6, 30),
+        cash_balances=[
+            CashBalance(
+                currency="USD",
+                starting_cash=Decimal("10000.00"),
+                ending_cash=Decimal("11000.00"),
+                ending_settled_cash=Decimal("10500.00"),
+            )
+        ],
+        positions=[sample_position],
+        trades=[sample_trade],
+    )
+
+
+class TestDecimalSerialization:
+    """Decimal must serialize to JSON strings, preserving precision."""
+
+    def test_trade_decimals_are_json_strings(self, sample_trade: Trade) -> None:
+        data = json.loads(sample_trade.model_dump_json())
+        # Trailing zeros preserved exactly as the source Decimal.
+        assert data["trade_price"] == "150.50"
+        assert data["trade_money"] == "-15050.00"
+        assert data["ib_commission"] == "-1.50"
+        # Strings, not floats.
+        assert isinstance(data["trade_price"], str)
+        assert isinstance(data["quantity"], str)
+
+    def test_position_decimals_are_json_strings(self, sample_position: Position) -> None:
+        data = json.loads(sample_position.model_dump_json())
+        assert data["mark_price"] == "150.00"
+        assert data["position_value"] == "15000.00"
+        assert isinstance(data["unrealized_pnl"], str)
+
+    def test_cash_summary_decimals_are_json_strings(self) -> None:
+        summary = CashSummary(
+            ClientAccountID="U1234567",
+            Currency="USD",
+            FromDate=date(2025, 1, 1),
+            ToDate=date(2025, 6, 30),
+            StartingCash=Decimal("1000.1200"),
+            EndingCash=Decimal("2000.00"),
+            EndingSettledCash=Decimal("1900.00"),
+        )
+        data = json.loads(summary.model_dump_json())
+        assert data["starting_cash"] == "1000.1200"
+        assert isinstance(data["ending_cash"], str)
+
+    def test_sentiment_score_decimals_are_json_strings(self) -> None:
+        score = SentimentScore(
+            score=Decimal("0.50"),
+            confidence=Decimal("0.80"),
+            timestamp=datetime(2025, 1, 2, 3, 4, 5),
+        )
+        data = json.loads(score.model_dump_json())
+        assert data["score"] == "0.50"
+        assert data["confidence"] == "0.80"
+
+    def test_nested_account_decimals_are_json_strings(self, sample_account: Account) -> None:
+        """Nested models (positions/trades/cash) keep Decimal-as-string."""
+        data = json.loads(sample_account.model_dump_json())
+        assert isinstance(data["positions"][0]["mark_price"], str)
+        assert isinstance(data["trades"][0]["trade_price"], str)
+        assert isinstance(data["cash_balances"][0]["ending_cash"], str)
+
+
+class TestDateSerialization:
+    """date / datetime must serialize to ISO 8601 strings."""
+
+    def test_trade_dates_are_iso_strings(self, sample_trade: Trade) -> None:
+        data = json.loads(sample_trade.model_dump_json())
+        assert data["trade_date"] == "2025-01-15"
+        assert data["settle_date"] == "2025-01-17"
+
+    def test_flex_statement_dates_are_iso_strings(self) -> None:
+        statement = FlexStatement(
+            query_id="Q1",
+            account_id="U1234567",
+            from_date=date(2025, 1, 1),
+            to_date=date(2025, 6, 30),
+            when_generated=datetime(2025, 7, 1, 12, 30, 0),
+            raw_data="<xml/>",
+        )
+        data = json.loads(statement.model_dump_json())
+        assert data["from_date"] == "2025-01-01"
+        assert data["when_generated"] == "2025-07-01T12:30:00"
+
+
+class TestNoDeprecationWarnings:
+    """Serialization must not emit Pydantic v1 deprecation warnings."""
+
+    def test_model_dump_json_emits_no_deprecation_warning(
+        self, sample_account: Account, sample_trade: Trade, sample_position: Position
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            sample_account.model_dump_json()
+            sample_trade.model_dump_json()
+            sample_position.model_dump_json()
+            sample_account.model_dump(mode="json")


### PR DESCRIPTION
## Summary

Resolves #118. Migrates the deprecated Pydantic v1 `class Config` / `json_encoders` pattern to v2 idioms, eliminating `PydanticDeprecatedSince20` warnings that would break under Pydantic v3.

**Key insight:** Pydantic v2's *default* JSON serialization already reproduces exactly what these `json_encoders` configured:
- `Decimal('1.2300')` → `"1.2300"` (string, trailing-zero precision preserved)
- `date` / `datetime` → ISO 8601 strings

So the encoders were redundant. Removing them is the idiomatic v2 approach and is forward-compatible with v3 (verified empirically against pydantic 2.12.5).

## Changes

- **Remove** redundant `class Config` + `json_encoders` blocks:
  - `api/models.py` (`FlexStatement`)
  - `models/trade.py`, `models/position.py`, `models/account.py` (2 classes), `models/portfolio.py`
  - `analyzers/sentiment/base.py` (`model_config = {"json_encoders": ...}`)
- **Convert** `class Config: populate_by_name = True` → `model_config = ConfigDict(populate_by_name=True)` in `api/models.py` (`AccountInfo`, `CashSummary`)
- **Add** `tests/models/test_serialization.py` — regression coverage for Decimal-as-string, ISO date serialization, nested-model serialization, and a no-deprecation-warning assertion
- **Gate** Pydantic deprecations in CI via pytest `filterwarnings = ["error::pydantic.PydanticDeprecationWarning"]` — scoped to pydantic only, so unrelated third-party `DeprecationWarning`s don't fail CI (implements issue task 4 concretely)

## Acceptance criteria

- [x] `class Config:` → `model_config = ConfigDict(...)` (where config was non-default)
- [x] `json_encoders={Decimal: str}` removed — default v2 behavior preserves Decimal→str
- [x] Existing Decimal→str serialization behavior preserved (regression tests)
- [x] CI deprecation gate introduced (scoped to pydantic range)
- [x] `uv run pytest`: **906 passed**, zero Pydantic deprecation warnings

## Testing

```
uv run pytest        # 906 passed, coverage 56.58% (gate 48%)
uv run ruff check    # All checks passed
uv run mypy          # Success: no issues found
```

No `json_encoders` or v1 `class Config:` config-blocks remain in `ib_sec_mcp/`.

## Parallel-safety

Owns `ib_sec_mcp/api/models.py`, `ib_sec_mcp/models/*.py`, `ib_sec_mcp/analyzers/sentiment/base.py` (+ tests, pyproject pytest config). Wave 1, file-isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)