### PR TITLE
fix(core): eliminate Decimal precision loss at the parse boundary (#119)

### DIFF
--- a/ib_sec_mcp/core/calculator.py
+++ b/ib_sec_mcp/core/calculator.py
@@ -53,6 +53,10 @@ class PerformanceCalculator:
         if initial_value == 0 or years == 0:
             return Decimal("0")
 
+        # float() is required here: math.pow supports a fractional exponent
+        # (1/years) that Decimal ** Decimal cannot express directly. The inputs
+        # form an exact Decimal ratio first, and the float result is re-quantized
+        # via Decimal(str(...)) so no float artifact leaks into callers.
         ratio = float(final_value / initial_value)
         power = 1.0 / float(years)
         cagr = (math.pow(ratio, power) - 1) * 100
@@ -131,7 +135,9 @@ class PerformanceCalculator:
         # Calculate mean return
         mean_return: Decimal = sum(returns, Decimal("0")) / len(returns)
 
-        # Calculate standard deviation
+        # Calculate standard deviation. Variance stays in exact Decimal; only the
+        # final square root needs float (math.sqrt has no Decimal equivalent in
+        # the stdlib) and is re-quantized via Decimal(str(...)).
         variance: Decimal = sum(((r - mean_return) ** 2 for r in returns), Decimal("0")) / (
             len(returns) - 1
         )
@@ -198,6 +204,10 @@ class PerformanceCalculator:
         if current_price == 0 or years_to_maturity == 0:
             return Decimal("0")
 
+        # float() is required for the fractional exponent (1/years_to_maturity)
+        # via math.pow. The ratio is formed as an exact Decimal first and the
+        # result is re-quantized via Decimal(str(...)) so callers see no float
+        # artifact.
         ratio = float(face_value / current_price)
         power = 1.0 / float(years_to_maturity)
         ytm = (math.pow(ratio, power) - 1) * 100

--- a/ib_sec_mcp/core/parsers.py
+++ b/ib_sec_mcp/core/parsers.py
@@ -8,7 +8,7 @@ from typing import Any
 from ib_sec_mcp.models.account import Account, CashBalance
 from ib_sec_mcp.models.position import Position
 from ib_sec_mcp.models.trade import AssetClass, BuySell, Trade
-from ib_sec_mcp.utils.validators import parse_decimal_safe
+from ib_sec_mcp.utils.validators import parse_decimal_safe, validate_xml_format
 
 
 class XMLParser:
@@ -100,30 +100,20 @@ class XMLParser:
             # Use BASE_SUMMARY (already converted to USD)
             balance = CashBalance(
                 currency="USD",
-                starting_cash=Decimal(
-                    parse_decimal_safe(base_summary_report.get("startingCash", "0"))
+                starting_cash=parse_decimal_safe(base_summary_report.get("startingCash", "0")),
+                ending_cash=parse_decimal_safe(base_summary_report.get("endingCash", "0")),
+                ending_settled_cash=parse_decimal_safe(
+                    base_summary_report.get("endingSettledCash", "0")
                 ),
-                ending_cash=Decimal(parse_decimal_safe(base_summary_report.get("endingCash", "0"))),
-                ending_settled_cash=Decimal(
-                    parse_decimal_safe(base_summary_report.get("endingSettledCash", "0"))
-                ),
-                deposits=Decimal(parse_decimal_safe(base_summary_report.get("deposits", "0"))),
-                withdrawals=Decimal(
-                    parse_decimal_safe(base_summary_report.get("withdrawals", "0"))
-                ),
-                dividends=Decimal(parse_decimal_safe(base_summary_report.get("dividends", "0"))),
-                interest=Decimal(
-                    parse_decimal_safe(base_summary_report.get("brokerInterest", "0"))
-                ),
-                commissions=Decimal(
-                    parse_decimal_safe(base_summary_report.get("commissions", "0"))
-                ),
-                fees=Decimal(parse_decimal_safe(base_summary_report.get("otherFees", "0"))),
-                net_trades_sales=Decimal(
-                    parse_decimal_safe(base_summary_report.get("netTradesSales", "0"))
-                ),
-                net_trades_purchases=Decimal(
-                    parse_decimal_safe(base_summary_report.get("netTradesPurchases", "0"))
+                deposits=parse_decimal_safe(base_summary_report.get("deposits", "0")),
+                withdrawals=parse_decimal_safe(base_summary_report.get("withdrawals", "0")),
+                dividends=parse_decimal_safe(base_summary_report.get("dividends", "0")),
+                interest=parse_decimal_safe(base_summary_report.get("brokerInterest", "0")),
+                commissions=parse_decimal_safe(base_summary_report.get("commissions", "0")),
+                fees=parse_decimal_safe(base_summary_report.get("otherFees", "0")),
+                net_trades_sales=parse_decimal_safe(base_summary_report.get("netTradesSales", "0")),
+                net_trades_purchases=parse_decimal_safe(
+                    base_summary_report.get("netTradesPurchases", "0")
                 ),
             )
             balances.append(balance)
@@ -134,21 +124,17 @@ class XMLParser:
 
                 balance = CashBalance(
                     currency=currency,
-                    starting_cash=Decimal(parse_decimal_safe(report.get("startingCash", "0"))),
-                    ending_cash=Decimal(parse_decimal_safe(report.get("endingCash", "0"))),
-                    ending_settled_cash=Decimal(
-                        parse_decimal_safe(report.get("endingSettledCash", "0"))
-                    ),
-                    deposits=Decimal(parse_decimal_safe(report.get("deposits", "0"))),
-                    withdrawals=Decimal(parse_decimal_safe(report.get("withdrawals", "0"))),
-                    dividends=Decimal(parse_decimal_safe(report.get("dividends", "0"))),
-                    interest=Decimal(parse_decimal_safe(report.get("brokerInterest", "0"))),
-                    commissions=Decimal(parse_decimal_safe(report.get("commissions", "0"))),
-                    fees=Decimal(parse_decimal_safe(report.get("otherFees", "0"))),
-                    net_trades_sales=Decimal(parse_decimal_safe(report.get("netTradesSales", "0"))),
-                    net_trades_purchases=Decimal(
-                        parse_decimal_safe(report.get("netTradesPurchases", "0"))
-                    ),
+                    starting_cash=parse_decimal_safe(report.get("startingCash", "0")),
+                    ending_cash=parse_decimal_safe(report.get("endingCash", "0")),
+                    ending_settled_cash=parse_decimal_safe(report.get("endingSettledCash", "0")),
+                    deposits=parse_decimal_safe(report.get("deposits", "0")),
+                    withdrawals=parse_decimal_safe(report.get("withdrawals", "0")),
+                    dividends=parse_decimal_safe(report.get("dividends", "0")),
+                    interest=parse_decimal_safe(report.get("brokerInterest", "0")),
+                    commissions=parse_decimal_safe(report.get("commissions", "0")),
+                    fees=parse_decimal_safe(report.get("otherFees", "0")),
+                    net_trades_sales=parse_decimal_safe(report.get("netTradesSales", "0")),
+                    net_trades_purchases=parse_decimal_safe(report.get("netTradesPurchases", "0")),
                 )
                 balances.append(balance)
 
@@ -177,8 +163,8 @@ class XMLParser:
                 maturity_date = XMLParser._parse_date_yyyymmdd(pos_elem.get("maturity"))
 
             # Parse quantity and calculate average cost
-            quantity = Decimal(parse_decimal_safe(pos_elem.get("position", "0")))
-            cost_basis = Decimal(parse_decimal_safe(pos_elem.get("costBasisMoney", "0")))
+            quantity = parse_decimal_safe(pos_elem.get("position", "0"))
+            cost_basis = parse_decimal_safe(pos_elem.get("costBasisMoney", "0"))
 
             # Get FX rate to convert to base currency (USD)
             # Create Decimal from string directly to avoid float precision artifacts
@@ -189,12 +175,10 @@ class XMLParser:
                 fx_rate = Decimal("1")
 
             # Apply FX rate to convert values to USD
-            position_value_local = Decimal(parse_decimal_safe(pos_elem.get("positionValue", "0")))
+            position_value_local = parse_decimal_safe(pos_elem.get("positionValue", "0"))
             position_value_usd = position_value_local * fx_rate
 
-            unrealized_pnl_local = Decimal(
-                parse_decimal_safe(pos_elem.get("fifoPnlUnrealized", "0"))
-            )
+            unrealized_pnl_local = parse_decimal_safe(pos_elem.get("fifoPnlUnrealized", "0"))
             unrealized_pnl_usd = unrealized_pnl_local * fx_rate
 
             cost_basis_usd = cost_basis * fx_rate
@@ -210,8 +194,8 @@ class XMLParser:
                 cusip=pos_elem.get("cusip"),
                 isin=pos_elem.get("isin"),
                 quantity=quantity,
-                multiplier=Decimal(parse_decimal_safe(pos_elem.get("multiplier", "1"))),
-                mark_price=Decimal(parse_decimal_safe(pos_elem.get("markPrice", "0"))),
+                multiplier=parse_decimal_safe(pos_elem.get("multiplier", "1")),
+                mark_price=parse_decimal_safe(pos_elem.get("markPrice", "0")),
                 position_value=position_value_usd,
                 average_cost=average_cost,
                 cost_basis=cost_basis_usd,
@@ -221,7 +205,7 @@ class XMLParser:
                 fx_rate_to_base=fx_rate,
                 position_date=position_date,
                 coupon_rate=(
-                    Decimal(parse_decimal_safe(pos_elem.get("coupon", "0")))
+                    parse_decimal_safe(pos_elem.get("coupon", "0"))
                     if pos_elem.get("coupon")
                     else None
                 ),
@@ -285,17 +269,15 @@ class XMLParser:
                 cusip=trade_elem.get("cusip"),
                 isin=trade_elem.get("isin"),
                 buy_sell=buy_sell,
-                quantity=Decimal(parse_decimal_safe(trade_elem.get("quantity", "0"))),
-                trade_price=Decimal(parse_decimal_safe(trade_elem.get("tradePrice", "0"))),
-                trade_money=Decimal(parse_decimal_safe(trade_elem.get("tradeMoney", "0"))),
+                quantity=parse_decimal_safe(trade_elem.get("quantity", "0")),
+                trade_price=parse_decimal_safe(trade_elem.get("tradePrice", "0")),
+                trade_money=parse_decimal_safe(trade_elem.get("tradeMoney", "0")),
                 currency=trade_elem.get("currency", "USD"),
-                fx_rate_to_base=Decimal(parse_decimal_safe(trade_elem.get("fxRateToBase", "1.0"))),
-                ib_commission=Decimal(parse_decimal_safe(trade_elem.get("ibCommission", "0"))),
+                fx_rate_to_base=parse_decimal_safe(trade_elem.get("fxRateToBase", "1.0")),
+                ib_commission=parse_decimal_safe(trade_elem.get("ibCommission", "0")),
                 ib_commission_currency=trade_elem.get("ibCommissionCurrency", "USD"),
-                fifo_pnl_realized=Decimal(
-                    parse_decimal_safe(trade_elem.get("fifoPnlRealized", "0"))
-                ),
-                mtm_pnl=Decimal(parse_decimal_safe(trade_elem.get("mtmPnl", "0"))),
+                fifo_pnl_realized=parse_decimal_safe(trade_elem.get("fifoPnlRealized", "0")),
+                mtm_pnl=parse_decimal_safe(trade_elem.get("mtmPnl", "0")),
                 order_id=trade_elem.get("orderID"),
                 execution_id=trade_elem.get("executionID"),
                 order_time=order_time,
@@ -422,10 +404,13 @@ class XMLParser:
 
 def detect_format(data: str) -> str:
     """
-    Validate XML format
+    Validate XML format (deprecated alias for :func:`validate_xml_format`).
 
-    IB Flex Query API returns data in XML format only.
-    CSV support has been removed.
+    .. deprecated::
+        IB Flex Query API returns XML only, so there is no format to "detect".
+        Prefer :func:`ib_sec_mcp.utils.validators.validate_xml_format`, which
+        expresses the intent (validation, not detection). This wrapper remains
+        for backward compatibility and always returns ``"xml"``.
 
     Args:
         data: Raw data string
@@ -436,13 +421,5 @@ def detect_format(data: str) -> str:
     Raises:
         ValueError: If data is not valid XML
     """
-    first_line = data.strip().split("\n")[0] if data.strip() else ""
-
-    if not first_line.startswith("<"):
-        raise ValueError(
-            "Invalid data format. Only XML format is supported. "
-            "CSV support has been removed. "
-            "IB Flex Query API returns XML data."
-        )
-
+    validate_xml_format(data)
     return "xml"

--- a/ib_sec_mcp/utils/validators.py
+++ b/ib_sec_mcp/utils/validators.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
 
 
 def validate_date(
@@ -141,28 +142,65 @@ def validate_account_id(account_id: str) -> bool:
     return bool(re.match(pattern, account_id))
 
 
-def parse_decimal_safe(value: str | int | float, default: float = 0.0) -> float:
+def parse_decimal_safe(
+    value: str | int | float | None,
+    default: Decimal = Decimal("0"),
+) -> Decimal:
     """
-    Safely parse decimal value
+    Safely parse a value into a ``Decimal`` without float precision loss.
+
+    Financial values must be created from a string (``Decimal(str(value))``)
+    rather than from a ``float``, otherwise binary floating-point artifacts are
+    baked in at the parse boundary. For example ``Decimal(0.1)`` yields
+    ``Decimal('0.1000000000000000055511151231257827021181583404541015625')``
+    whereas ``Decimal("0.1")`` is exact. This helper guarantees the latter for
+    every code path so callers never need to wrap the result in ``Decimal``.
 
     Args:
-        value: Value to parse
-        default: Default value if parsing fails
+        value: Value to parse (string, int, float, or None)
+        default: Default ``Decimal`` returned when the input is empty or invalid
 
     Returns:
-        Parsed float value or default
+        Parsed ``Decimal`` value, or ``default`` on empty/invalid input
     """
     if value is None or value == "":
         return default
 
     try:
         if isinstance(value, str):
-            # Remove commas and whitespace
+            # Remove thousands separators and surrounding whitespace
             cleaned = value.replace(",", "").strip()
-            return float(cleaned)
-        return float(value)
-    except (ValueError, TypeError):
+            if not cleaned:
+                return default
+            return Decimal(cleaned)
+        # int/float: route through str() so float binary artifacts are not
+        # propagated into the resulting Decimal.
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
         return default
+
+
+def validate_xml_format(data: str) -> None:
+    """
+    Validate that ``data`` is XML.
+
+    IB Flex Query API returns data in XML format only (CSV support has been
+    removed), so this is a guard rather than a multi-format detector.
+
+    Args:
+        data: Raw data string
+
+    Raises:
+        ValueError: If ``data`` is not valid XML (does not start with ``<``)
+    """
+    first_line = data.strip().split("\n")[0] if data.strip() else ""
+
+    if not first_line.startswith("<"):
+        raise ValueError(
+            "Invalid data format. Only XML format is supported. "
+            "CSV support has been removed. "
+            "IB Flex Query API returns XML data."
+        )
 
 
 def validate_symbol(symbol: str) -> bool:

--- a/ib_sec_mcp/utils/validators.py
+++ b/ib_sec_mcp/utils/validators.py
@@ -144,7 +144,7 @@ def validate_account_id(account_id: str) -> bool:
 
 def parse_decimal_safe(
     value: str | int | float | Decimal | None,
-    default: Decimal = Decimal("0"),
+    default: str | int | float | Decimal = Decimal("0"),
 ) -> Decimal:
     """
     Safely parse a value into a ``Decimal`` without float precision loss.
@@ -158,13 +158,20 @@ def parse_decimal_safe(
 
     Args:
         value: Value to parse (string, int, float, Decimal, or None)
-        default: Default ``Decimal`` returned when the input is empty or invalid
+        default: Fallback for empty/invalid input. Accepts any numeric-like type
+            and is normalized to ``Decimal`` so this helper always returns a
+            ``Decimal`` (even when a legacy caller passes a ``float`` default).
 
     Returns:
-        Parsed ``Decimal`` value, or ``default`` on empty/invalid input
+        Parsed ``Decimal`` value, or the normalized ``default`` on empty/invalid
+        input
     """
+    # Normalize the fallback first so every return path yields a Decimal and a
+    # float default can never reintroduce a binary artifact downstream.
+    default_decimal = default if isinstance(default, Decimal) else Decimal(str(default))
+
     if value is None or value == "":
-        return default
+        return default_decimal
 
     # Already a Decimal: return as-is, avoiding a redundant str() round-trip.
     if isinstance(value, Decimal):
@@ -175,13 +182,13 @@ def parse_decimal_safe(
             # Remove thousands separators and surrounding whitespace
             cleaned = value.replace(",", "").strip()
             if not cleaned:
-                return default
+                return default_decimal
             return Decimal(cleaned)
         # int/float: route through str() so float binary artifacts are not
         # propagated into the resulting Decimal.
         return Decimal(str(value))
     except (InvalidOperation, ValueError, TypeError):
-        return default
+        return default_decimal
 
 
 def validate_xml_format(data: str) -> None:

--- a/ib_sec_mcp/utils/validators.py
+++ b/ib_sec_mcp/utils/validators.py
@@ -143,7 +143,7 @@ def validate_account_id(account_id: str) -> bool:
 
 
 def parse_decimal_safe(
-    value: str | int | float | None,
+    value: str | int | float | Decimal | None,
     default: Decimal = Decimal("0"),
 ) -> Decimal:
     """
@@ -157,7 +157,7 @@ def parse_decimal_safe(
     every code path so callers never need to wrap the result in ``Decimal``.
 
     Args:
-        value: Value to parse (string, int, float, or None)
+        value: Value to parse (string, int, float, Decimal, or None)
         default: Default ``Decimal`` returned when the input is empty or invalid
 
     Returns:
@@ -165,6 +165,10 @@ def parse_decimal_safe(
     """
     if value is None or value == "":
         return default
+
+    # Already a Decimal: return as-is, avoiding a redundant str() round-trip.
+    if isinstance(value, Decimal):
+        return value
 
     try:
         if isinstance(value, str):
@@ -193,9 +197,11 @@ def validate_xml_format(data: str) -> None:
     Raises:
         ValueError: If ``data`` is not valid XML (does not start with ``<``)
     """
-    first_line = data.strip().split("\n")[0] if data.strip() else ""
+    # Find the first non-whitespace character without copying/splitting the
+    # whole payload (XML statements can be large): O(1) for well-formed input.
+    first_char = next((char for char in data if not char.isspace()), "")
 
-    if not first_line.startswith("<"):
+    if first_char != "<":
         raise ValueError(
             "Invalid data format. Only XML format is supported. "
             "CSV support has been removed. "

--- a/tests/core/test_calculator.py
+++ b/tests/core/test_calculator.py
@@ -356,3 +356,68 @@ class TestCalculateRiskRewardRatio:
         # abs() is applied in the method
         ratio = PerformanceCalculator.calculate_risk_reward_ratio(Decimal("200"), Decimal("-100"))
         assert ratio == Decimal("2")
+
+
+class TestCalculatorPrecision:
+    """Regression tests for Issue #119: Decimal precision in the calculator.
+
+    Pure-Decimal methods must be exact even with operands that are inexact as
+    binary floats. Methods that necessarily use float (math.pow / math.sqrt for
+    fractional exponents and square roots) must still return a Decimal with no
+    leaked binary artifact.
+    """
+
+    def test_roi_is_exact_with_inexact_float_operands(self) -> None:
+        # 0.1 and 0.3 are inexact as float; ROI must be an exact Decimal.
+        roi = PerformanceCalculator.calculate_roi(Decimal("0.3"), Decimal("0.6"))
+        assert roi == Decimal("100")
+        assert isinstance(roi, Decimal)
+
+    def test_commission_rate_is_exact(self) -> None:
+        rate = PerformanceCalculator.calculate_commission_rate(Decimal("0.1"), Decimal("100"))
+        # Exact value (0.1 / 100 * 100); Decimal preserves scale ("0.100").
+        assert rate == Decimal("0.1")
+        assert isinstance(rate, Decimal)
+
+    def test_profit_factor_is_exact(self) -> None:
+        trades = [
+            _make_trade(Decimal("0.1")),
+            _make_trade(Decimal("0.2")),
+            _make_trade(Decimal("-0.1")),
+        ]
+        # gross_profit = 0.3, gross_loss = 0.1 -> exactly 3.
+        assert PerformanceCalculator.calculate_profit_factor(trades) == Decimal("3")
+
+    def test_cagr_returns_decimal_without_artifact(self) -> None:
+        # Doubling over 1 year => 100% CAGR, exactly representable after re-quantize.
+        cagr = PerformanceCalculator.calculate_cagr(Decimal("100"), Decimal("200"), Decimal("1"))
+        assert isinstance(cagr, Decimal)
+        assert cagr == Decimal("100")
+
+    def test_cagr_fractional_is_decimal(self) -> None:
+        cagr = PerformanceCalculator.calculate_cagr(Decimal("1000"), Decimal("1331"), Decimal("3"))
+        assert isinstance(cagr, Decimal)
+        # 1331/1000 = 1.331 = 1.1^3 -> ~10% CAGR
+        assert abs(cagr - Decimal("10")) < Decimal("0.0001")
+
+    def test_ytm_returns_decimal_without_artifact(self) -> None:
+        # Price 100 -> face 121 over 2 years => 10% YTM.
+        ytm = PerformanceCalculator.calculate_ytm(Decimal("121"), Decimal("100"), Decimal("2"))
+        assert isinstance(ytm, Decimal)
+        assert abs(ytm - Decimal("10")) < Decimal("0.0001")
+
+    def test_sharpe_returns_decimal(self) -> None:
+        returns = [Decimal("0.1"), Decimal("0.2"), Decimal("0.15"), Decimal("0.05")]
+        sharpe = PerformanceCalculator.calculate_sharpe_ratio(returns)
+        assert isinstance(sharpe, Decimal)
+
+    def test_phantom_income_is_decimal(self) -> None:
+        # Decimal ** Decimal path (constant yield) must stay Decimal.
+        income = PerformanceCalculator.calculate_phantom_income(
+            purchase_price=Decimal("800"),
+            face_value=Decimal("1000"),
+            years_to_maturity=Decimal("5"),
+            days_held=365,
+        )
+        assert isinstance(income, Decimal)
+        assert income > Decimal("0")

--- a/tests/core/test_parsers.py
+++ b/tests/core/test_parsers.py
@@ -545,3 +545,101 @@ class TestDetectFormat:
     def test_json_raises(self) -> None:
         with pytest.raises(ValueError, match="Only XML format is supported"):
             detect_format('{"key": "value"}')
+
+
+# XML containing amounts that are NOT exactly representable as binary floats.
+# Under the old float-based parse boundary these produced artifacts such as
+# Decimal('150.5000000000000113686...'); they must now be exact.
+PRECISION_XML = """\
+<FlexQueryResponse>
+  <FlexStatements>
+    <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20250131">
+      <AccountInformation accountId="U1234567" acctAlias="Precision"/>
+      <CashReport>
+        <CashReportCurrency currency="BASE_SUMMARY"
+          startingCash="0.1" endingCash="0.3" endingSettledCash="1.005"
+          deposits="19.99" withdrawals="0.07" dividends="12.34"
+          brokerInterest="0.2" commissions="-1.005" otherFees="-0.1"
+          netTradesSales="1234567.89" netTradesPurchases="-0.3"/>
+      </CashReport>
+      <OpenPositions>
+        <OpenPosition symbol="AAPL" description="APPLE INC" assetCategory="STK"
+          position="3" markPrice="0.1" positionValue="0.3"
+          costBasisMoney="0.3" fifoPnlUnrealized="0.1"
+          reportDate="20250131" multiplier="1" currency="USD"
+          fxRateToBase="1"/>
+      </OpenPositions>
+      <Trades>
+        <Trade tradeID="T001" symbol="AAPL" description="APPLE INC"
+          assetCategory="STK" buySell="BUY" quantity="3"
+          tradePrice="0.1" tradeMoney="0.3" tradeDate="20250115"
+          settleDateTarget="20250117" currency="USD" fxRateToBase="1.0"
+          ibCommission="-1.005" ibCommissionCurrency="USD"
+          fifoPnlRealized="0.07" mtmPnl="0.2"/>
+      </Trades>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>"""
+
+
+class TestParsePrecision:
+    """Regression tests for Issue #119: no float artifacts at the parse boundary."""
+
+    def test_cash_balance_amounts_are_exact(self) -> None:
+        account = XMLParser.to_account(
+            PRECISION_XML,
+            from_date=date(2025, 1, 1),
+            to_date=date(2025, 1, 31),
+        )
+        cash = account.cash_balances[0]
+        assert cash.starting_cash == Decimal("0.1")
+        assert cash.ending_cash == Decimal("0.3")
+        assert cash.ending_settled_cash == Decimal("1.005")
+        assert cash.deposits == Decimal("19.99")
+        assert cash.withdrawals == Decimal("0.07")
+        assert cash.dividends == Decimal("12.34")
+        assert cash.interest == Decimal("0.2")
+        assert cash.commissions == Decimal("-1.005")
+        assert cash.fees == Decimal("-0.1")
+        assert cash.net_trades_sales == Decimal("1234567.89")
+        assert cash.net_trades_purchases == Decimal("-0.3")
+        # Exact string round-trip proves no trailing float artifact.
+        assert str(cash.ending_settled_cash) == "1.005"
+
+    def test_position_amounts_are_exact(self) -> None:
+        account = XMLParser.to_account(
+            PRECISION_XML,
+            from_date=date(2025, 1, 1),
+            to_date=date(2025, 1, 31),
+        )
+        position = account.positions[0]
+        assert position.mark_price == Decimal("0.1")
+        assert position.position_value == Decimal("0.3")
+        assert position.cost_basis == Decimal("0.3")
+        assert position.unrealized_pnl == Decimal("0.1")
+        assert str(position.mark_price) == "0.1"
+
+    def test_trade_amounts_are_exact(self) -> None:
+        account = XMLParser.to_account(
+            PRECISION_XML,
+            from_date=date(2025, 1, 1),
+            to_date=date(2025, 1, 31),
+        )
+        trade = account.trades[0]
+        assert trade.trade_price == Decimal("0.1")
+        assert trade.trade_money == Decimal("0.3")
+        assert trade.ib_commission == Decimal("-1.005")
+        assert trade.fifo_pnl_realized == Decimal("0.07")
+        assert trade.mtm_pnl == Decimal("0.2")
+        assert str(trade.ib_commission) == "-1.005"
+
+    def test_classic_float_sum_holds(self) -> None:
+        """0.1 + 0.2 == 0.3 after parsing (would fail under float parsing)."""
+        account = XMLParser.to_account(
+            PRECISION_XML,
+            from_date=date(2025, 1, 1),
+            to_date=date(2025, 1, 31),
+        )
+        cash = account.cash_balances[0]
+        assert cash.starting_cash + cash.interest == cash.ending_cash
+        assert cash.starting_cash + cash.interest == Decimal("0.3")

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -60,6 +60,17 @@ class TestParseDecimalSafe:
         """A float input must not bake its binary artifact into the Decimal."""
         assert parse_decimal_safe(0.1) == Decimal("0.1")
 
+    def test_decimal_input_returned_as_is(self) -> None:
+        """An existing Decimal is returned unchanged (no str() round-trip)."""
+        value = Decimal("123.456")
+        result = parse_decimal_safe(value)
+        assert result == value
+        assert isinstance(result, Decimal)
+
+    def test_decimal_input_preserves_high_precision(self) -> None:
+        value = Decimal("1.000000000000000000001")
+        assert parse_decimal_safe(value) == value
+
     def test_none_returns_default(self) -> None:
         assert parse_decimal_safe(None) == Decimal("0")
 

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -1,0 +1,168 @@
+"""Tests for ib_sec_mcp.utils.validators.
+
+Focus areas:
+- parse_decimal_safe must return exact Decimal values with no float artifacts
+  at the parse boundary (Issue #119).
+- validate_xml_format guards that only XML is accepted.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from ib_sec_mcp.utils.validators import (
+    parse_decimal_safe,
+    validate_account_id,
+    validate_cusip,
+    validate_date,
+    validate_isin,
+    validate_symbol,
+    validate_xml_format,
+)
+
+
+class TestParseDecimalSafe:
+    """parse_decimal_safe returns exact Decimal without float precision loss."""
+
+    def test_returns_decimal_type(self) -> None:
+        assert isinstance(parse_decimal_safe("100.50"), Decimal)
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["0.1", "0.2", "0.3", "1.005", "150.50", "12.34", "0.07", "19.99"],
+    )
+    def test_no_float_artifacts(self, raw: str) -> None:
+        """Values that are inexact as binary floats must stay exact as Decimal."""
+        # Exact: equals Decimal(str) of the literal.
+        assert parse_decimal_safe(raw) == Decimal(raw)
+        # And demonstrably free of the float artifact that the old impl produced.
+        assert str(parse_decimal_safe(raw)) == raw
+
+    def test_classic_float_error_case(self) -> None:
+        """0.1 + 0.2 == 0.3 holds with Decimal parsing (would fail with float)."""
+        result = parse_decimal_safe("0.1") + parse_decimal_safe("0.2")
+        assert result == parse_decimal_safe("0.3")
+        assert result == Decimal("0.3")
+
+    def test_strips_commas_and_whitespace(self) -> None:
+        assert parse_decimal_safe("  1,234,567.89  ") == Decimal("1234567.89")
+
+    def test_negative_values(self) -> None:
+        assert parse_decimal_safe("-25.50") == Decimal("-25.50")
+
+    def test_int_input(self) -> None:
+        result = parse_decimal_safe(100)
+        assert result == Decimal("100")
+        assert isinstance(result, Decimal)
+
+    def test_float_input_routes_through_str(self) -> None:
+        """A float input must not bake its binary artifact into the Decimal."""
+        assert parse_decimal_safe(0.1) == Decimal("0.1")
+
+    def test_none_returns_default(self) -> None:
+        assert parse_decimal_safe(None) == Decimal("0")
+
+    def test_empty_string_returns_default(self) -> None:
+        assert parse_decimal_safe("") == Decimal("0")
+
+    def test_whitespace_only_returns_default(self) -> None:
+        assert parse_decimal_safe("   ") == Decimal("0")
+
+    def test_invalid_string_returns_default(self) -> None:
+        assert parse_decimal_safe("not-a-number") == Decimal("0")
+
+    def test_custom_default(self) -> None:
+        assert parse_decimal_safe("", default=Decimal("1")) == Decimal("1")
+        assert parse_decimal_safe("bad", default=Decimal("-1")) == Decimal("-1")
+
+    def test_default_is_decimal_type(self) -> None:
+        result = parse_decimal_safe(None, default=Decimal("5"))
+        assert isinstance(result, Decimal)
+
+
+class TestValidateXmlFormat:
+    """validate_xml_format raises on non-XML input."""
+
+    def test_valid_xml(self) -> None:
+        # Should not raise.
+        validate_xml_format("<FlexQueryResponse/>")
+
+    def test_xml_with_declaration(self) -> None:
+        validate_xml_format('<?xml version="1.0"?><root/>')
+
+    def test_xml_with_leading_whitespace(self) -> None:
+        validate_xml_format("  \n  <root/>")
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            "AccountId,Symbol,Quantity\nU123,AAPL,100",  # CSV
+            "",  # empty
+            "   \n  ",  # whitespace only
+            '{"key": "value"}',  # JSON
+        ],
+    )
+    def test_non_xml_raises(self, data: str) -> None:
+        with pytest.raises(ValueError, match="Only XML format is supported"):
+            validate_xml_format(data)
+
+    def test_returns_none(self) -> None:
+        assert validate_xml_format("<root/>") is None
+
+
+class TestIdentifierValidators:
+    """Regression coverage for the identifier/symbol validators."""
+
+    def test_valid_cusip(self) -> None:
+        # 037833100 = Apple Inc. (valid check digit)
+        assert validate_cusip("037833100") is True
+
+    def test_invalid_cusip_check_digit(self) -> None:
+        assert validate_cusip("037833101") is False
+
+    def test_cusip_wrong_length(self) -> None:
+        assert validate_cusip("0378331") is False
+
+    def test_isin_wrong_length(self) -> None:
+        assert validate_isin("US037833100") is False
+
+    def test_isin_non_alpha_country_code(self) -> None:
+        assert validate_isin("120378331005") is False
+
+    def test_isin_non_digit_check(self) -> None:
+        assert validate_isin("US037833100X") is False
+
+    def test_valid_account_id(self) -> None:
+        assert validate_account_id("U1234567") is True
+        assert validate_account_id("U12345678") is True
+
+    def test_invalid_account_id(self) -> None:
+        assert validate_account_id("X1234567") is False
+        assert validate_account_id("U123") is False
+        assert validate_account_id("") is False
+
+    def test_valid_symbol(self) -> None:
+        assert validate_symbol("AAPL") is True
+        assert validate_symbol("BTC-USD") is True
+        assert validate_symbol("USDJPY=X") is True
+
+    def test_invalid_symbol(self) -> None:
+        assert validate_symbol("") is False
+        assert validate_symbol("   ") is False
+        assert validate_symbol("TOOLONGSYMBOL123") is False
+
+
+class TestValidateDate:
+    """Coverage for validate_date."""
+
+    def test_parse_string(self) -> None:
+        assert validate_date("2025-01-15") == date(2025, 1, 15)
+
+    def test_passthrough_date(self) -> None:
+        d = date(2025, 6, 1)
+        assert validate_date(d) == d
+
+    def test_invalid_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid date format"):
+            validate_date("15-01-2025")

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -91,6 +91,21 @@ class TestParseDecimalSafe:
         result = parse_decimal_safe(None, default=Decimal("5"))
         assert isinstance(result, Decimal)
 
+    @pytest.mark.parametrize("empty", [None, "", "   ", "not-a-number"])
+    def test_float_default_is_normalized_to_decimal(self, empty: object) -> None:
+        """A legacy float default must be normalized so the artifact-prone path
+        Decimal(parse_decimal_safe('', default=0.1)) can never resurface."""
+        result = parse_decimal_safe(empty, default=0.1)  # type: ignore[arg-type]
+        assert isinstance(result, Decimal)
+        assert result == Decimal("0.1")
+        # No binary artifact, even if a caller re-wraps in Decimal.
+        assert Decimal(str(result)) == Decimal("0.1")
+
+    def test_int_default_is_normalized(self) -> None:
+        result = parse_decimal_safe("", default=5)  # type: ignore[arg-type]
+        assert result == Decimal("5")
+        assert isinstance(result, Decimal)
+
 
 class TestValidateXmlFormat:
     """validate_xml_format raises on non-XML input."""


### PR DESCRIPTION
## Summary

Resolves #119. Removes float-based precision loss at the XML parse boundary and substantially raises core-engine test coverage.

The root cause: `parse_decimal_safe()` returned a `float`, and every call site in `core/parsers.py` wrapped it as `Decimal(float_value)` — baking binary floating-point artifacts into financial values at ingest (e.g. `Decimal(0.1)` → `Decimal('0.1000000000000000055...')`). Project convention is `Decimal(str(value))`.

## Changes

- **`utils/validators.py`**
  - `parse_decimal_safe()` now returns `Decimal` (via `Decimal(str(...))` / `Decimal(cleaned_string)`), with a `Decimal` default. Callers no longer need to wrap the result.
  - Added `validate_xml_format(data) -> None` — the properly-named home for XML-only format validation.
- **`core/parsers.py`**
  - Removed all redundant `Decimal(parse_decimal_safe(...))` wrappers — no `float` is ever constructed on the money path.
  - `detect_format()` reimplemented as a **documented, backward-compatible deprecated delegator** to `validate_xml_format()`. The misleading "format detection" (always `"xml"` since CSV removal) is gone, while the ~15 existing call sites across MCP tools / CLI keep working unchanged (kept out of this PR's blast radius for parallel-safety).
- **`core/calculator.py`**
  - Audited `float` usage. `calculate_cagr` / `calculate_ytm` / `calculate_sharpe_ratio` legitimately need `math.pow` / `math.sqrt` (fractional exponent / square root with no stdlib Decimal equivalent); added comments documenting that inputs stay exact Decimal and results are re-quantized via `Decimal(str(...))`. No avoidable float remains.

## Tests

- New `tests/utils/test_validators.py`: exhaustive `parse_decimal_safe` precision tests (incl. the classic `0.1 + 0.2 == 0.3`), `validate_xml_format`, and validator coverage.
- `tests/core/test_parsers.py`: `TestParsePrecision` proves cash / position / trade amounts are exact Decimals with no float artifacts.
- `tests/core/test_calculator.py`: `TestCalculatorPrecision` for Decimal exactness and return types.

**Coverage:** `parsers.py` 14% → 98%, `calculator.py` 21% → 100%, `validators.py` 7% → 70%, `aggregator.py` 100%.

## Acceptance criteria

- [x] Parsed amounts carry no float error (proven by tests)
- [x] core + validators coverage raised
- [x] `detect_format` cleaned up (relocated to a named validator + deprecated alias)

## Verification

- `uv run ruff check` / `ruff format` — clean
- `uv run mypy` on changed sources — clean
- `uv run pytest` — **951 passed**, total coverage 57.4%

## Notes / follow-ups

- `validate_isin()` rejects genuinely valid ISINs (e.g. Apple `US0378331005`) — a pre-existing bug in the Luhn implementation, out of scope here. Worth a follow-up issue.
- No call-site files outside the issue's declared ownership were modified (parallel-safe with Wave 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)