### PR TITLE
fix(validators): correct Luhn parity in validate_isin (#137)

### DIFF
--- a/ib_sec_mcp/utils/validators.py
+++ b/ib_sec_mcp/utils/validators.py
@@ -108,12 +108,15 @@ def validate_isin(isin: str) -> bool:
             value = str(ord(char.upper()) - ord("A") + 10)
             digits.extend(value)
 
-    # Double every second digit from right
+    # Double every second digit from the right. For ISIN check-digit
+    # computation the rightmost digit of the expanded payload (the position
+    # adjacent to the check digit) is doubled, so we double even indices
+    # (0-based) of the reversed string.
     total = 0
     reversed_digits = "".join(digits)[::-1]
     for i, digit in enumerate(reversed_digits):
         digit_value: int = int(digit)
-        if i % 2 == 1:
+        if i % 2 == 0:
             digit_value *= 2
             if digit_value > 9:
                 digit_value = digit_value // 10 + digit_value % 10

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -150,6 +150,33 @@ class TestIdentifierValidators:
     def test_cusip_wrong_length(self) -> None:
         assert validate_cusip("0378331") is False
 
+    @pytest.mark.parametrize(
+        "isin",
+        [
+            "US0378331005",  # Apple Inc.
+            "US5949181045",  # Microsoft Corp.
+            "US38259P5089",  # Google (contains a letter in the identifier)
+            "GB0002634946",  # BAE Systems
+            "DE000BAY0017",  # Bayer AG
+            "FR0000131104",  # BNP Paribas
+            "NL0000235190",  # Airbus
+        ],
+    )
+    def test_valid_isin_check_digit(self, isin: str) -> None:
+        """Genuinely valid ISINs must pass the Luhn check (regression for #137)."""
+        assert validate_isin(isin) is True
+
+    @pytest.mark.parametrize(
+        "isin",
+        [
+            "US0378331004",  # Apple ISIN with wrong check digit
+            "US0378331006",
+            "GB0002634940",  # BAE Systems with wrong check digit
+        ],
+    )
+    def test_invalid_isin_check_digit(self, isin: str) -> None:
+        assert validate_isin(isin) is False
+
     def test_isin_wrong_length(self) -> None:
         assert validate_isin("US037833100") is False
 


### PR DESCRIPTION
## Summary

Fixes #137. `validate_isin()` rejected genuinely valid ISINs (e.g. Apple `US0378331005`) because the Luhn check-digit computation doubled the wrong set of digits.

## Root Cause

The ISIN check-digit algorithm expands letters to two digits, then applies the Luhn "double every second digit" rule starting from the **rightmost** payload digit. After reversing the expanded string, that rightmost digit sits at index `0`, so even (0-based) indices must be doubled. The code used `i % 2 == 1`, doubling the wrong parity — off by one.

For `US0378331005` the expanded payload is `3028037833100`; the corrected parity yields a Luhn sum of 45 → check digit `5` ✓ (the buggy parity gave `8`, so it returned `False`).

## Changes

- `ib_sec_mcp/utils/validators.py`: `validate_isin` doubling parity `i % 2 == 1` → `i % 2 == 0`, with a clarifying comment.
- `tests/utils/test_validators.py`: regression tests for known-valid ISINs (Apple, Microsoft, Google, BAE Systems, Bayer, BNP Paribas, Airbus) and wrong-check-digit rejections.

## Acceptance Criteria

- [x] `validate_isin("US0378331005")` and other known-valid ISINs return `True`
- [x] Invalid check digits still return `False`
- [x] Regression test added in `tests/utils/test_validators.py`

## Testing

- `uv run python -m pytest` → **972 passed**, coverage 58.2% (gate 48%)
- `ruff format`, `ruff check`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)