### PR TITLE
feat(mcp): gate CP Gateway live-trading tools behind IB_ENABLE_LIVE_TRADING (default off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,32 @@ uv run pre-commit run --all-files
 - **Timeout Protection**: All operations have timeout limits
 - **Retry Logic**: Automatic retry for transient errors (max 3 attempts)
 
+### Live Trading Gate
+
+CP Gateway **live-trading** and **order-management** tools (`place_order`, `modify_order`,
+`cancel_order`, `cancel_all_orders`, `get_live_orders`, `get_live_account_balance`,
+`get_live_positions`, `check_gateway_status`) are **disabled by default**. They are only
+registered with the MCP server when `IB_ENABLE_LIVE_TRADING` is explicitly enabled:
+
+```bash
+export IB_ENABLE_LIVE_TRADING=1   # accepts 1 / true / yes
+ib-sec-mcp
+```
+
+When the flag is off, these 8 tools are not advertised to MCP clients at all. The local
+`limit_orders` tools (`add_limit_order`, `update_limit_order`, `get_pending_orders`,
+`check_order_proximity`, `get_order_history`, `sync_limit_orders`) remain available in both
+states. This registration gate is purely additive — once enabled, the existing per-call
+guards still apply as a second line of defense:
+
+| Variable                   | Default  | Effect                                               |
+| -------------------------- | -------- | ---------------------------------------------------- |
+| `IB_ENABLE_LIVE_TRADING`   | off      | Registers the 8 CP Gateway live-trading tools        |
+| `IB_READ_ONLY`             | off      | Blocks all order placement/modification/cancellation |
+| `IB_ORDER_DRY_RUN`         | **on**   | Simulates orders without submitting (set `0` to arm) |
+| `IB_MAX_ORDER_AMOUNT_USD`  | `50000`  | Per-order amount limit                               |
+| `IB_DAILY_ORDER_LIMIT_USD` | `200000` | Cumulative daily order amount limit                  |
+
 ### Debug Mode
 
 ```bash

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -816,6 +816,34 @@ Analyze market sentiment from multiple sources.
 
 ---
 
+## Live Trading & Order Management (gated)
+
+CP Gateway live-trading and order-management tools are **disabled by default** and only
+registered when `IB_ENABLE_LIVE_TRADING` is enabled (accepts `1` / `true` / `yes`). When the
+flag is off, these 8 tools are not advertised to MCP clients.
+
+**Gated tools** (require `IB_ENABLE_LIVE_TRADING=1`):
+
+| Module             | Tools                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| `live_trading`     | `get_live_orders`, `get_live_account_balance`, `get_live_positions`, `check_gateway_status` |
+| `order_management` | `place_order`, `modify_order`, `cancel_order`, `cancel_all_orders`                          |
+
+**Always-on** (local limit-order tools, never gated): `add_limit_order`, `update_limit_order`,
+`get_pending_orders`, `check_order_proximity`, `get_order_history`, `sync_limit_orders`.
+`sync_limit_orders` touches the CP Gateway optionally and degrades gracefully (gateway
+unavailability is a soft skip, not an error).
+
+The registration gate is additive. Once enabled, the per-call safety guards still apply:
+`IB_READ_ONLY`, `IB_ORDER_DRY_RUN` (default **on**), `IB_MAX_ORDER_AMOUNT_USD` (default
+`50000`), and `IB_DAILY_ORDER_LIMIT_USD` (default `200000`). See the [README Security
+section](../README.md#live-trading-gate) for the full flag table.
+
+> Per-tool parameter documentation for these tools is tracked separately (see issues
+> #125 / #126 / #127).
+
+---
+
 ## Resources
 
 Read-only data access via URI patterns. Resources automatically use the most recent data file.

--- a/ib_sec_mcp/mcp/server.py
+++ b/ib_sec_mcp/mcp/server.py
@@ -78,7 +78,15 @@ def main() -> None:
     # Check for debug mode from environment
     import os
 
+    from dotenv import load_dotenv
+
     from ib_sec_mcp.utils.logger import configure_logging as configure_app_logging
+
+    # Load .env before anything reads os.environ. Registration-time configuration
+    # such as IB_ENABLE_LIVE_TRADING (which gates tool registration in
+    # register_all_tools) is evaluated at startup, so the .env file must be loaded
+    # here rather than lazily at tool-call time (via Config.load()).
+    load_dotenv()
 
     enable_debug = os.getenv("IB_DEBUG", "").lower() in ("1", "true", "yes")
 

--- a/ib_sec_mcp/mcp/tools/__init__.py
+++ b/ib_sec_mcp/mcp/tools/__init__.py
@@ -5,9 +5,18 @@ Central registration point for all MCP tools.
 
 from fastmcp import FastMCP
 
+from ib_sec_mcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 
 def register_all_tools(mcp: FastMCP) -> None:
-    """Register all IB Analytics tools with MCP server"""
+    """Register all IB Analytics tools with MCP server.
+
+    CP Gateway live-trading and order-management tools are gated behind the
+    ``IB_ENABLE_LIVE_TRADING`` flag (default off). The local ``limit_orders``
+    tools are always registered.
+    """
 
     # Import and register tools from each module
     from ib_sec_mcp.mcp.tools.composable_data import register_composable_data_tools
@@ -22,7 +31,10 @@ def register_all_tools(mcp: FastMCP) -> None:
     from ib_sec_mcp.mcp.tools.live_trading import register_live_trading_tools
     from ib_sec_mcp.mcp.tools.market_comparison import register_market_comparison_tools
     from ib_sec_mcp.mcp.tools.options import register_options_tools
-    from ib_sec_mcp.mcp.tools.order_management import register_order_management_tools
+    from ib_sec_mcp.mcp.tools.order_management import (
+        is_live_trading_enabled,
+        register_order_management_tools,
+    )
     from ib_sec_mcp.mcp.tools.portfolio_analytics import (
         register_portfolio_analytics_tools,
     )
@@ -53,9 +65,22 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_sentiment_analysis_tools(mcp)  # Add sentiment analysis tools
     register_rebalancing_tools(mcp)  # Add rebalancing tools
     register_sector_fx_tools(mcp)  # Add sector allocation and FX exposure tools
-    register_limit_order_tools(mcp)  # Add limit order management tools
-    register_live_trading_tools(mcp)  # Add live trading tools via CP Gateway
-    register_order_management_tools(mcp)  # Add order management tools (place/modify/cancel)
+    register_limit_order_tools(mcp)  # Always-on: local limit order management tools
+
+    # Gated: CP Gateway live-trading + order-management tools (default OFF)
+    if is_live_trading_enabled():
+        register_live_trading_tools(mcp)  # Add live trading tools via CP Gateway
+        register_order_management_tools(mcp)  # Add order management (place/modify/cancel)
+        logger.info(
+            "Live-trading tools ENABLED via IB_ENABLE_LIVE_TRADING "
+            "(live_trading + order_management registered)"
+        )
+    else:
+        logger.info(
+            "Live-trading tools DISABLED (set IB_ENABLE_LIVE_TRADING=1 to enable "
+            "CP Gateway live_trading + order_management tools)"
+        )
+
     register_daily_monitor_tools(mcp)  # Add daily monitor tools
     register_earnings_calendar_tools(mcp)  # Add earnings and dividend calendar tools
 

--- a/ib_sec_mcp/mcp/tools/order_management.py
+++ b/ib_sec_mcp/mcp/tools/order_management.py
@@ -67,8 +67,11 @@ def is_live_trading_enabled() -> bool:
     when this flag is explicitly enabled. This is a registration-level gate; the
     per-call guards (``IB_READ_ONLY``, ``IB_ORDER_DRY_RUN``, ``IB_MAX_ORDER_AMOUNT_USD``,
     ``IB_DAILY_ORDER_LIMIT_USD``) remain the second line of defense once enabled.
+
+    The value is matched case-insensitively, so ``1``, ``true``, ``TRUE``, ``yes``,
+    and ``Yes`` all enable the tools.
     """
-    return os.environ.get("IB_ENABLE_LIVE_TRADING", "0") in ("1", "true", "yes")
+    return os.environ.get("IB_ENABLE_LIVE_TRADING", "0").strip().lower() in ("1", "true", "yes")
 
 
 def is_read_only() -> bool:

--- a/ib_sec_mcp/mcp/tools/order_management.py
+++ b/ib_sec_mcp/mcp/tools/order_management.py
@@ -59,6 +59,18 @@ DEFAULT_ORDER_LOG_PATH = Path("data/processed/order_log.jsonl")
 # ---------------------------------------------------------------------------
 
 
+def is_live_trading_enabled() -> bool:
+    """Check if CP Gateway live-trading tools are enabled via IB_ENABLE_LIVE_TRADING.
+
+    Disabled by default. The live-trading (``live_trading.py``) and order-management
+    (``order_management.py``) tool groups are only registered with the MCP server
+    when this flag is explicitly enabled. This is a registration-level gate; the
+    per-call guards (``IB_READ_ONLY``, ``IB_ORDER_DRY_RUN``, ``IB_MAX_ORDER_AMOUNT_USD``,
+    ``IB_DAILY_ORDER_LIMIT_USD``) remain the second line of defense once enabled.
+    """
+    return os.environ.get("IB_ENABLE_LIVE_TRADING", "0") in ("1", "true", "yes")
+
+
 def is_read_only() -> bool:
     """Check if read-only mode is enabled via IB_READ_ONLY env var."""
     return os.environ.get("IB_READ_ONLY", "0") in ("1", "true", "yes")

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -84,13 +84,23 @@ EXPECTED_TOOLS = {
     # sector_fx
     "analyze_sector_allocation",
     "analyze_fx_exposure",
-    # limit_orders
+    # limit_orders (always-on, not gated)
     "add_limit_order",
     "update_limit_order",
     "get_pending_orders",
     "check_order_proximity",
     "get_order_history",
     "sync_limit_orders",
+    # daily_monitor
+    "sync_daily_snapshot",
+    "get_sync_status",
+    # earnings_calendar
+    "get_earnings_calendar",
+}
+
+# CP Gateway live-trading tools gated behind IB_ENABLE_LIVE_TRADING (default OFF).
+# Absent from the default server; present only when the flag is enabled.
+LIVE_TRADING_TOOLS = {
     # live_trading
     "get_live_orders",
     "get_live_account_balance",
@@ -101,11 +111,6 @@ EXPECTED_TOOLS = {
     "modify_order",
     "cancel_order",
     "cancel_all_orders",
-    # daily_monitor
-    "sync_daily_snapshot",
-    "get_sync_status",
-    # earnings_calendar
-    "get_earnings_calendar",
 }
 
 # Non-template resources
@@ -164,6 +169,13 @@ class TestMCPServerStartup:
             f"Unexpected: {registered_tools - EXPECTED_TOOLS}"
         )
 
+    def test_live_trading_tools_absent_by_default(self, registered_tools: set[str]) -> None:
+        """CP Gateway live-trading tools are NOT advertised when the flag is unset"""
+        assert registered_tools.isdisjoint(LIVE_TRADING_TOOLS), (
+            f"Live-trading tools must be gated off by default, but found: "
+            f"{registered_tools & LIVE_TRADING_TOOLS}"
+        )
+
     def test_all_resource_uris_registered(
         self, registered_resources: set[str], registered_templates: set[str]
     ) -> None:
@@ -183,3 +195,44 @@ class TestMCPServerStartup:
         """create_server(enable_debug=True) also creates a valid FastMCP instance"""
         debug_server = create_server(enable_debug=True)
         assert isinstance(debug_server, FastMCP)
+
+
+class TestLiveTradingGate:
+    """Issue #140: IB_ENABLE_LIVE_TRADING registration gate for CP Gateway tools"""
+
+    def test_gated_tools_absent_when_flag_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With IB_ENABLE_LIVE_TRADING unset, the 8 gated tools are absent and base tools present"""
+        monkeypatch.delenv("IB_ENABLE_LIVE_TRADING", raising=False)
+        server = create_server()
+        tools = asyncio.run(list_tool_names(server))
+        assert tools.isdisjoint(LIVE_TRADING_TOOLS)
+        assert tools >= EXPECTED_TOOLS
+
+    @pytest.mark.parametrize("flag_value", ["1", "true", "yes"])
+    def test_gated_tools_present_when_flag_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, flag_value: str
+    ) -> None:
+        """With IB_ENABLE_LIVE_TRADING enabled, all 8 gated tools are advertised"""
+        monkeypatch.setenv("IB_ENABLE_LIVE_TRADING", flag_value)
+        server = create_server()
+        tools = asyncio.run(list_tool_names(server))
+        assert tools >= LIVE_TRADING_TOOLS, f"Missing: {LIVE_TRADING_TOOLS - tools}"
+        assert tools >= EXPECTED_TOOLS
+
+    def test_local_limit_order_tools_present_in_both_states(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The 5 local limit_orders tools are advertised regardless of the flag"""
+        local_tools = {
+            "add_limit_order",
+            "update_limit_order",
+            "get_pending_orders",
+            "check_order_proximity",
+            "get_order_history",
+        }
+        monkeypatch.delenv("IB_ENABLE_LIVE_TRADING", raising=False)
+        off_tools = asyncio.run(list_tool_names(create_server()))
+        monkeypatch.setenv("IB_ENABLE_LIVE_TRADING", "1")
+        on_tools = asyncio.run(list_tool_names(create_server()))
+        assert local_tools <= off_tools
+        assert local_tools <= on_tools

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -6,7 +6,7 @@ Verifies that the server starts correctly and all expected tools and resources a
 import asyncio
 import os
 from collections.abc import Iterator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp import FastMCP
@@ -251,3 +251,26 @@ class TestLiveTradingGate:
         on_tools = asyncio.run(list_tool_names(create_server()))
         assert local_tools <= off_tools
         assert local_tools <= on_tools
+
+    def test_main_loads_dotenv_before_creating_server(self) -> None:
+        """main() must load .env before create_server() so the startup-time gate sees it.
+
+        The IB_ENABLE_LIVE_TRADING gate is evaluated during register_all_tools() at
+        startup. If .env is not loaded first, a flag set only in .env would be invisible
+        and the gated tools would never register.
+        """
+        from ib_sec_mcp.mcp import server as server_module
+
+        manager = MagicMock()
+        with (
+            patch("dotenv.load_dotenv", manager.load_dotenv),
+            patch.object(server_module, "create_server", manager.create_server),
+        ):
+            server_module.main()
+
+        names = [call[0] for call in manager.mock_calls]
+        assert "load_dotenv" in names, "main() must call load_dotenv()"
+        assert "create_server" in names
+        assert names.index("load_dotenv") < names.index("create_server"), (
+            "load_dotenv() must run before create_server()"
+        )

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -4,6 +4,9 @@ Verifies that the server starts correctly and all expected tools and resources a
 """
 
 import asyncio
+import os
+from collections.abc import Iterator
+from unittest.mock import patch
 
 import pytest
 from fastmcp import FastMCP
@@ -134,6 +137,18 @@ EXPECTED_RESOURCE_TEMPLATES = {
 class TestMCPServerStartup:
     """Smoke tests for Issue #52: MCP server startup and component registration"""
 
+    @pytest.fixture(scope="class", autouse=True)
+    def _isolate_live_trading_flag(self) -> Iterator[None]:
+        """Ensure IB_ENABLE_LIVE_TRADING does not leak from the ambient env.
+
+        The class-scoped ``server`` fixture reads this flag at creation time, so an
+        ambient ``IB_ENABLE_LIVE_TRADING=1`` (developer shell or CI) would otherwise
+        register the gated tools and break the default-state assertions.
+        """
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("IB_ENABLE_LIVE_TRADING", None)
+            yield
+
     @pytest.fixture(scope="class")
     def server(self) -> FastMCP:
         """Create a server instance for testing (no network calls)"""
@@ -208,11 +223,11 @@ class TestLiveTradingGate:
         assert tools.isdisjoint(LIVE_TRADING_TOOLS)
         assert tools >= EXPECTED_TOOLS
 
-    @pytest.mark.parametrize("flag_value", ["1", "true", "yes"])
+    @pytest.mark.parametrize("flag_value", ["1", "true", "yes", "TRUE", "Yes", " true "])
     def test_gated_tools_present_when_flag_enabled(
         self, monkeypatch: pytest.MonkeyPatch, flag_value: str
     ) -> None:
-        """With IB_ENABLE_LIVE_TRADING enabled, all 8 gated tools are advertised"""
+        """With IB_ENABLE_LIVE_TRADING enabled (case-insensitive), all 8 tools are advertised"""
         monkeypatch.setenv("IB_ENABLE_LIVE_TRADING", flag_value)
         server = create_server()
         tools = asyncio.run(list_tool_names(server))


### PR DESCRIPTION
## Summary

Resolves #140 (derived from spike #122, Option B+).

The 14 CP Gateway live-trading tools were registered unconditionally and advertised to every MCP client, even when no Gateway was running. This PR gates the **8 order-touching tools** behind a new `IB_ENABLE_LIVE_TRADING` flag (**default OFF**), while keeping the **5 local `limit_orders` tools** (and the graceful-degrading `sync_limit_orders`) always-on.

## Changes

- **`order_management.py`**: add `is_live_trading_enabled()` — parses `IB_ENABLE_LIVE_TRADING` (accepts `1`/`true`/`yes`), matching the existing `IB_*` safety-flag style.
- **`tools/__init__.py`**: `register_all_tools()` conditionally registers `register_live_trading_tools` + `register_order_management_tools` only when the flag is on; `register_limit_order_tools` stays unconditional. Logs the posture at startup so operators can confirm.
- **`tests/mcp/test_server.py`**: split `EXPECTED_TOOLS` from a new `LIVE_TRADING_TOOLS` set; new `TestLiveTradingGate` asserts the 8 tools are absent by default, present when enabled (`1`/`true`/`yes`), and that local `limit_orders` tools appear in both states.
- **Docs**: `README.md` (flag table) and `docs/mcp-tools-reference.md` (gated section, coordinating with #125/#126/#127).

## Gated tools (require `IB_ENABLE_LIVE_TRADING=1`)

| Module | Tools |
| --- | --- |
| `live_trading` | `get_live_orders`, `get_live_account_balance`, `get_live_positions`, `check_gateway_status` |
| `order_management` | `place_order`, `modify_order`, `cancel_order`, `cancel_all_orders` |

## Safety note

Purely additive gating. The per-call guards (`IB_READ_ONLY`, `IB_ORDER_DRY_RUN` default ON, `IB_MAX_ORDER_AMOUNT_USD`, `IB_DAILY_ORDER_LIMIT_USD`) remain the second line of defense once the flag is enabled.

## Acceptance criteria

- [x] No env set → the 8 tools are NOT advertised
- [x] `IB_ENABLE_LIVE_TRADING=1` → all 8 tools advertised and behave as today
- [x] The 5 local `limit_orders` tools advertised in both cases
- [x] Tests cover both states

## Testing

- `uv run python -m pytest` → **968 passed**, coverage 57.92% (≥48% threshold)
- `uv run ruff check ib_sec_mcp tests` → all checks passed
- `uv run python -m mypy` (changed files) → no issues
- `uv run ruff format` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)