### PR TITLE
test(mcp): add tests for market-data tools (stock_data, options, technical, market/etf comparison)

### DIFF
--- a/tests/mcp/test_etf_comparison.py
+++ b/tests/mcp/test_etf_comparison.py
@@ -106,9 +106,13 @@ def patch_ticker(
     """Install :class:`FakeTicker` with per-symbol history and info payloads."""
 
     def _apply(histories: dict[str, Any], infos: dict[str, Any]) -> None:
-        monkeypatch.setattr(FakeTicker, "histories", histories)
-        monkeypatch.setattr(FakeTicker, "infos", infos)
-        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+        # Use a fresh per-call subclass so concurrent tests never share state.
+        class LocalFakeTicker(FakeTicker):
+            pass
+
+        LocalFakeTicker.histories = histories
+        LocalFakeTicker.infos = infos
+        monkeypatch.setattr(PATCH_TARGET, LocalFakeTicker)
 
     return _apply
 

--- a/tests/mcp/test_etf_comparison.py
+++ b/tests/mcp/test_etf_comparison.py
@@ -1,0 +1,473 @@
+"""Tests for ETF comparison MCP tools.
+
+These tests register :func:`compare_etf_performance` on a real
+:class:`fastmcp.FastMCP` instance and invoke it through the FastMCP tool API so
+that the production code path is exercised (and recorded by coverage). All
+``yfinance`` access is mocked via ``yfinance.Ticker``, so the suite is
+network-independent.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import ValidationError, YahooFinanceError
+from ib_sec_mcp.mcp.tools.etf_comparison import register_etf_comparison_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+PATCH_TARGET = "yfinance.Ticker"
+
+
+def _make_history(closes: list[float]) -> pd.DataFrame:
+    """Build a daily ``Close`` history DataFrame indexed by business days."""
+    index = pd.date_range("2025-01-01", periods=len(closes), freq="B")
+    return pd.DataFrame({"Close": closes}, index=index)
+
+
+def _steady_growth(start: float, daily_rate: float, days: int) -> list[float]:
+    """Generate a deterministic compounding price series."""
+    return [start * (1 + daily_rate) ** i for i in range(days)]
+
+
+def _random_walk(
+    start: float, days: int, seed: int, drift: float = 0.0005, vol: float = 0.01
+) -> list[float]:
+    """Generate a deterministic random-walk price series with real variability.
+
+    Unlike a smooth compounding curve, this produces both up and down days so
+    downside-based metrics (Sortino, max drawdown) are well defined and the
+    return series has non-zero variance for correlation calculations.
+    """
+    rng = np.random.default_rng(seed)
+    shocks = rng.normal(drift, vol, days)
+    prices = [start]
+    for shock in shocks[1:]:
+        prices.append(prices[-1] * (1 + shock))
+    return prices
+
+
+def _correlated_walk(base_prices: list[float], seed: int, noise: float = 0.001) -> list[float]:
+    """Build a price series whose returns closely track ``base_prices``."""
+    base = pd.Series(base_prices).pct_change().fillna(0.0).to_numpy()
+    rng = np.random.default_rng(seed)
+    new_returns = base * 0.9 + rng.normal(0, noise, len(base))
+    prices = [base_prices[0]]
+    for ret in new_returns[1:]:
+        prices.append(prices[-1] * (1 + ret))
+    return prices
+
+
+class FakeTicker:
+    """yfinance ticker fake dispatching per-symbol history/info payloads.
+
+    ``histories`` and ``infos`` are class-level dicts keyed by symbol. A value
+    that is an :class:`Exception` instance is raised to simulate API failures.
+    """
+
+    histories: dict[str, Any] = {}
+    infos: dict[str, Any] = {}
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def history(self, period: str = "1y", auto_adjust: bool = True) -> pd.DataFrame:
+        value = self.histories[self.symbol]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    @property
+    def info(self) -> dict[str, Any]:
+        value = self.infos[self.symbol]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with the ETF comparison tool registered."""
+    mcp = FastMCP("test")
+    register_etf_comparison_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_ticker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[dict[str, Any], dict[str, Any]], None]:
+    """Install :class:`FakeTicker` with per-symbol history and info payloads."""
+
+    def _apply(histories: dict[str, Any], infos: dict[str, Any]) -> None:
+        monkeypatch.setattr(FakeTicker, "histories", histories)
+        monkeypatch.setattr(FakeTicker, "infos", infos)
+        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+
+    return _apply
+
+
+def _default_info(**overrides: Any) -> dict[str, Any]:
+    """A baseline yfinance ``.info`` dict with optional overrides."""
+    info = {
+        "longName": "Test ETF",
+        "category": "Bonds",
+        "dividendYield": 0.02,
+        "dividendRate": 1.5,
+        "trailingAnnualDividendYield": 0.018,
+        "annualReportExpenseRatio": 0.0007,
+        "currentPrice": 100.0,
+        "fiftyTwoWeekHigh": 110.0,
+        "fiftyTwoWeekLow": 90.0,
+    }
+    info.update(overrides)
+    return info
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_happy_path(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """Two ETFs plus SPY benchmark produce a full comparison with ranking."""
+    # AAA grows faster than BBB, so AAA must be the best performer.
+    aaa_hist = _make_history(_steady_growth(100.0, 0.001, 260))
+    bbb_hist = _make_history(_steady_growth(100.0, 0.0003, 260))
+    spy_hist = _make_history(_steady_growth(100.0, 0.0005, 260))
+
+    patch_ticker(
+        {
+            "AAA": aaa_hist,
+            "BBB": bbb_hist,
+            "SPY": spy_hist,
+        },
+        {
+            "AAA": _default_info(longName="Alpha ETF", dividendYield=0.01),
+            "BBB": _default_info(longName="Beta ETF", dividendYield=0.05),
+            "SPY": _default_info(longName="SPDR S&P 500"),
+        },
+    )
+
+    result = await call_tool_fn(
+        test_mcp, "compare_etf_performance", symbols="AAA,BBB", period="1y", ctx=None
+    )
+    data = json.loads(result)
+
+    # Top-level structure
+    assert set(data) == {
+        "comparison_summary",
+        "performance_comparison",
+        "correlation_analysis",
+        "investment_insights",
+    }
+
+    summary = data["comparison_summary"]
+    assert summary["symbols"] == ["AAA", "BBB"]
+    assert summary["period"] == "1y"
+    assert summary["num_symbols_analyzed"] == 2
+
+    # AAA compounds faster -> best total return; BBB has the higher dividend yield.
+    assert summary["best_performer"]["symbol"] == "AAA"
+    assert summary["highest_dividend"]["symbol"] == "BBB"
+
+    # Per-ETF metric blocks exist with expected nested keys.
+    perf = data["performance_comparison"]
+    assert set(perf) == {"AAA", "BBB"}
+    aaa = perf["AAA"]
+    assert set(aaa) == {
+        "returns",
+        "risk",
+        "dividends",
+        "costs",
+        "market_metrics",
+        "info",
+    }
+    assert aaa["returns"]["total_return_pct"] > bbb_total(perf)
+    assert aaa["info"]["long_name"] == "Alpha ETF"
+    # dividendYield 0.05 -> 5.0 pct (multiplied by 100 in source)
+    assert perf["BBB"]["dividends"]["yield_pct"] == pytest.approx(5.0)
+    # Expense ratio 0.0007 -> 0.07 pct, cost per 10k = 7.0
+    assert aaa["costs"]["expense_ratio_pct"] == pytest.approx(0.07)
+    assert aaa["costs"]["estimated_annual_cost_per_10k"] == pytest.approx(7.0)
+    # _returns_series scratch key must be stripped from the output.
+    assert "_returns_series" not in aaa
+
+    # Correlation analysis: self-correlation is 1.0, matrix square over the symbols.
+    matrix = data["correlation_analysis"]["matrix"]
+    assert set(matrix) == {"AAA", "BBB"}
+    assert matrix["AAA"]["AAA"] == pytest.approx(1.0)
+
+    # Investment insights reference the ranked symbols.
+    insights = data["investment_insights"]
+    assert insights["best_total_return"].startswith("AAA")
+    assert isinstance(insights["recommendations"], list)
+
+
+def bbb_total(perf: dict[str, Any]) -> float:
+    return float(perf["BBB"]["returns"]["total_return_pct"])
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_high_correlation_pair(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """Two near-identical series are flagged as a high-correlation pair."""
+    base = _random_walk(100.0, 260, seed=1)
+    aaa_hist = _make_history(base)
+    # CCC tracks AAA's day-to-day returns closely -> correlation > 0.7.
+    ccc_hist = _make_history(_correlated_walk(base, seed=2))
+    spy_hist = _make_history(_random_walk(100.0, 260, seed=3))
+
+    patch_ticker(
+        {"AAA": aaa_hist, "CCC": ccc_hist, "SPY": spy_hist},
+        {
+            "AAA": _default_info(),
+            "CCC": _default_info(),
+            "SPY": _default_info(),
+        },
+    )
+
+    result = await call_tool_fn(test_mcp, "compare_etf_performance", symbols="AAA,CCC", ctx=None)
+    data = json.loads(result)
+
+    pairs = data["correlation_analysis"]["high_correlation_pairs"]
+    assert len(pairs) == 1
+    pair = pairs[0]
+    assert {pair["symbol1"], pair["symbol2"]} == {"AAA", "CCC"}
+    assert abs(pair["correlation"]) > 0.7
+
+
+# ---------------------------------------------------------------------------
+# 2. One symbol fails, others succeed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_skips_empty_symbol(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """A symbol returning an empty history is dropped, others still analyzed."""
+    good_hist = _make_history(_steady_growth(100.0, 0.0008, 260))
+    spy_hist = _make_history(_steady_growth(100.0, 0.0005, 260))
+
+    patch_ticker(
+        {
+            "GOOD": good_hist,
+            "EMPTY": pd.DataFrame({"Close": []}),
+            "SPY": spy_hist,
+        },
+        {
+            "GOOD": _default_info(),
+            "EMPTY": _default_info(),
+            "SPY": _default_info(),
+        },
+    )
+
+    result = await call_tool_fn(test_mcp, "compare_etf_performance", symbols="GOOD,EMPTY", ctx=None)
+    data = json.loads(result)
+
+    assert data["comparison_summary"]["symbols"] == ["GOOD"]
+    assert data["comparison_summary"]["num_symbols_analyzed"] == 1
+    assert set(data["performance_comparison"]) == {"GOOD"}
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_skips_raising_symbol(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """A symbol whose fetch raises is silently dropped (per-symbol try/except)."""
+    good_hist = _make_history(_steady_growth(100.0, 0.0008, 260))
+    spy_hist = _make_history(_steady_growth(100.0, 0.0005, 260))
+
+    patch_ticker(
+        {
+            "GOOD": good_hist,
+            "BROKEN": RuntimeError("yahoo exploded"),
+            "SPY": spy_hist,
+        },
+        {
+            "GOOD": _default_info(),
+            "BROKEN": _default_info(),
+            "SPY": _default_info(),
+        },
+    )
+
+    result = await call_tool_fn(
+        test_mcp, "compare_etf_performance", symbols="GOOD,BROKEN", ctx=None
+    )
+    data = json.loads(result)
+
+    assert set(data["performance_comparison"]) == {"GOOD"}
+    assert data["comparison_summary"]["num_symbols_analyzed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_all_fail_raises(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """When no symbol yields data, a YahooFinanceError is raised."""
+    patch_ticker(
+        {
+            "AAA": pd.DataFrame({"Close": []}),
+            "BBB": pd.DataFrame({"Close": []}),
+            "SPY": _make_history(_steady_growth(100.0, 0.0005, 260)),
+        },
+        {
+            "AAA": _default_info(),
+            "BBB": _default_info(),
+            "SPY": _default_info(),
+        },
+    )
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(test_mcp, "compare_etf_performance", symbols="AAA,BBB", ctx=None)
+
+
+# ---------------------------------------------------------------------------
+# 3. Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_invalid_symbol_raises(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """An invalid symbol is rejected by validate_symbol before any fetch."""
+    # No ticker should be fetched, but install a fake to avoid network anyway.
+    patch_ticker({}, {})
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(test_mcp, "compare_etf_performance", symbols="AAA,!!bad!!", ctx=None)
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_invalid_period_raises(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """An unsupported period is rejected by validate_period."""
+    patch_ticker({}, {})
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "compare_etf_performance",
+            symbols="AAA",
+            period="bogus",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_too_many_symbols_raises(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """More than 10 symbols is rejected before any fetch."""
+    patch_ticker({}, {})
+    symbols = ",".join(f"SYM{i}" for i in range(11))
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(test_mcp, "compare_etf_performance", symbols=symbols, ctx=None)
+
+
+# ---------------------------------------------------------------------------
+# 4. Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_single_etf(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """A single ETF still produces a complete, self-consistent comparison."""
+    aaa_hist = _make_history(_steady_growth(100.0, 0.0006, 260))
+    spy_hist = _make_history(_steady_growth(100.0, 0.0005, 260))
+
+    patch_ticker(
+        {"AAA": aaa_hist, "SPY": spy_hist},
+        {"AAA": _default_info(longName="Solo ETF"), "SPY": _default_info()},
+    )
+
+    result = await call_tool_fn(test_mcp, "compare_etf_performance", symbols="AAA", ctx=None)
+    data = json.loads(result)
+
+    summary = data["comparison_summary"]
+    assert summary["num_symbols_analyzed"] == 1
+    # With one symbol it is simultaneously best/worst on every dimension.
+    assert summary["best_performer"]["symbol"] == "AAA"
+    assert summary["lowest_volatility"]["symbol"] == "AAA"
+    assert summary["best_risk_adjusted"]["symbol"] == "AAA"
+    assert summary["highest_dividend"]["symbol"] == "AAA"
+    # Self-correlation only.
+    assert data["correlation_analysis"]["matrix"]["AAA"]["AAA"] == pytest.approx(1.0)
+    assert data["correlation_analysis"]["high_correlation_pairs"] == []
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_benchmark_spy_failure_is_tolerated(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """A failing SPY benchmark fetch drops the symbol relying on it.
+
+    SPY history is fetched per-symbol for beta. The source wraps each ETF's
+    computation in a try/except that returns ``None`` on any exception, so a
+    broken SPY removes that symbol's data. With only one symbol depending on
+    SPY, the result is a YahooFinanceError ("could not fetch data").
+    """
+    aaa_hist = _make_history(_steady_growth(100.0, 0.0006, 260))
+
+    patch_ticker(
+        {
+            "AAA": aaa_hist,
+            "SPY": RuntimeError("benchmark unavailable"),
+        },
+        {"AAA": _default_info(), "SPY": _default_info()},
+    )
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(test_mcp, "compare_etf_performance", symbols="AAA", ctx=None)
+
+
+@pytest.mark.asyncio
+async def test_compare_etf_performance_financial_values_are_numeric(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any], dict[str, Any]], None],
+) -> None:
+    """Metric values are JSON numbers (no NaN/inf leaking into the payload)."""
+    # A real random walk has down days, so downside-based metrics are finite.
+    aaa_hist = _make_history(_random_walk(100.0, 260, seed=7))
+    spy_hist = _make_history(_random_walk(100.0, 260, seed=8))
+
+    patch_ticker(
+        {"AAA": aaa_hist, "SPY": spy_hist},
+        {"AAA": _default_info(), "SPY": _default_info()},
+    )
+
+    result = await call_tool_fn(test_mcp, "compare_etf_performance", symbols="AAA", ctx=None)
+    data = json.loads(result)
+    risk = data["performance_comparison"]["AAA"]["risk"]
+
+    for key in ("volatility_pct", "sharpe_ratio", "sortino_ratio", "max_drawdown_pct"):
+        value = risk[key]
+        assert isinstance(value, (int, float))
+        assert not np.isnan(value)
+        assert not np.isinf(value)

--- a/tests/mcp/test_market_comparison.py
+++ b/tests/mcp/test_market_comparison.py
@@ -1,0 +1,419 @@
+"""Tests for market comparison MCP tools.
+
+These tests register the tools on a real :class:`fastmcp.FastMCP` instance and
+invoke them through the FastMCP tool API so the production code path is
+exercised (and recorded by coverage). All yfinance access is mocked via a
+symbol-dispatching :class:`FakeTicker`, so the suite is network-independent.
+
+Because :func:`compare_with_benchmark` imports ``yfinance`` lazily *inside* the
+tool function (``import yfinance as yf``), the patch target is the real
+``yfinance.Ticker`` attribute rather than a module-local alias.
+"""
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import ValidationError, YahooFinanceError
+from ib_sec_mcp.mcp.tools.market_comparison import register_market_comparison_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+PATCH_TARGET = "yfinance.Ticker"
+
+
+class FakeTicker:
+    """yfinance ticker fake dispatching on the requested symbol.
+
+    Class-level dicts hold per-symbol payloads:
+
+    - ``histories``: DataFrame returned by ``.history(period=...)``
+    - ``infos``: dict returned by the ``.info`` property
+    - ``recommendations_data``: DataFrame returned by ``.recommendations``
+    - ``calendars``: dict returned by the ``.calendar`` property
+
+    A payload that is an ``Exception`` instance is raised, allowing failure
+    simulation per access point.
+    """
+
+    histories: dict[str, Any] = {}
+    infos: dict[str, Any] = {}
+    recommendations_data: dict[str, Any] = {}
+    calendars: dict[str, Any] = {}
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def history(self, period: str = "1y") -> Any:
+        value = self.histories[self.symbol]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    @property
+    def info(self) -> Any:
+        value = self.infos.get(self.symbol, {})
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    @property
+    def recommendations(self) -> Any:
+        return self.recommendations_data.get(self.symbol)
+
+    @property
+    def calendar(self) -> Any:
+        return self.calendars.get(self.symbol)
+
+
+def _make_history(closes: list[float]) -> pd.DataFrame:
+    """Build a minimal history DataFrame with a deterministic Close series."""
+    return pd.DataFrame({"Close": closes})
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with the market comparison tools registered."""
+    mcp = FastMCP("test")
+    register_market_comparison_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Install FakeTicker with the supplied per-symbol payloads.
+
+    ``monkeypatch.setattr`` restores both ``yfinance.Ticker`` and the
+    class-level payload dicts after each test, preventing state leakage.
+    """
+
+    def _apply(
+        *,
+        histories: dict[str, Any] | None = None,
+        infos: dict[str, Any] | None = None,
+        recommendations: dict[str, Any] | None = None,
+        calendars: dict[str, Any] | None = None,
+    ) -> None:
+        monkeypatch.setattr(FakeTicker, "histories", histories or {})
+        monkeypatch.setattr(FakeTicker, "infos", infos or {})
+        monkeypatch.setattr(FakeTicker, "recommendations_data", recommendations or {})
+        monkeypatch.setattr(FakeTicker, "calendars", calendars or {})
+        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+
+    return _apply
+
+
+# ---------------------------------------------------------------------------
+# compare_with_benchmark
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compare_with_benchmark_happy_path(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """Valid inputs produce the full comparison payload with expected keys.
+
+    The stock rises 20% (100 -> 120) while the benchmark rises 10%
+    (100 -> 110), so the stock outperforms by ~10 percentage points.
+    """
+    patch_ticker(
+        histories={
+            "AAPL": _make_history([100.0, 105.0, 110.0, 115.0, 120.0]),
+            "SPY": _make_history([100.0, 102.5, 105.0, 107.5, 110.0]),
+        }
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "compare_with_benchmark",
+        symbol="AAPL",
+        benchmark="SPY",
+        period="1y",
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["symbol"] == "AAPL"
+    assert data["benchmark"] == "SPY"
+    assert data["period"] == "1y"
+
+    perf = data["performance"]
+    assert perf["stock_return_pct"] == 20.0
+    assert perf["benchmark_return_pct"] == 10.0
+    assert perf["outperformance_pct"] == 10.0
+
+    risk = data["risk_metrics"]
+    # Perfectly co-linear (both are straight lines) -> correlation == 1.0
+    assert risk["correlation"] == 1.0
+    assert "beta" in risk
+    assert "alpha_pct" in risk
+
+    interp = data["interpretation"]
+    assert set(interp) == {"beta", "alpha", "sharpe"}
+
+
+@pytest.mark.asyncio
+async def test_compare_with_benchmark_detects_underperformance(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """A declining stock vs a rising benchmark yields negative outperformance."""
+    patch_ticker(
+        histories={
+            "TSLA": _make_history([100.0, 95.0, 90.0, 85.0, 80.0]),
+            "SPY": _make_history([100.0, 103.0, 106.0, 109.0, 112.0]),
+        }
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "compare_with_benchmark",
+        symbol="TSLA",
+        benchmark="SPY",
+        period="6mo",
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["performance"]["stock_return_pct"] == -20.0
+    assert data["performance"]["benchmark_return_pct"] == 12.0
+    assert data["performance"]["outperformance_pct"] == -32.0
+    assert data["interpretation"]["alpha"].startswith("Underperformed")
+
+
+@pytest.mark.asyncio
+async def test_compare_with_benchmark_invalid_symbol_raises(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """An invalid symbol is rejected before any yfinance access."""
+    patch_ticker(histories={})
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "compare_with_benchmark",
+            symbol="!!bad!!",
+            benchmark="SPY",
+            period="1y",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_compare_with_benchmark_invalid_period_raises(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """An unsupported period string is rejected by the validator."""
+    patch_ticker(histories={})
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "compare_with_benchmark",
+            symbol="AAPL",
+            benchmark="SPY",
+            period="7y",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_compare_with_benchmark_empty_dataframe_raises_yahoo_error(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """An empty history DataFrame surfaces as a YahooFinanceError."""
+    patch_ticker(
+        histories={
+            "AAPL": pd.DataFrame({"Close": []}),
+            "SPY": _make_history([100.0, 110.0]),
+        }
+    )
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "compare_with_benchmark",
+            symbol="AAPL",
+            benchmark="SPY",
+            period="1y",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_compare_with_benchmark_yfinance_failure_wrapped(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """An unexpected yfinance error is wrapped into a YahooFinanceError."""
+    patch_ticker(
+        histories={
+            "AAPL": RuntimeError("network down"),
+            "SPY": _make_history([100.0, 110.0]),
+        }
+    )
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "compare_with_benchmark",
+            symbol="AAPL",
+            benchmark="SPY",
+            period="1y",
+            ctx=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_analyst_consensus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_analyst_consensus_happy_path(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """Info, recommendations and calendar are aggregated into consensus output."""
+    recommendations = pd.DataFrame(
+        [
+            {"strongBuy": 5, "buy": 10, "hold": 3, "sell": 1, "strongSell": 0},
+        ]
+    )
+    patch_ticker(
+        infos={
+            "AAPL": {
+                "currentPrice": 100.0,
+                "targetMeanPrice": 120.0,
+                "targetHighPrice": 150.0,
+                "targetLowPrice": 90.0,
+                "targetMedianPrice": 118.0,
+                "numberOfAnalystOpinions": 19,
+            }
+        },
+        recommendations={"AAPL": recommendations},
+        calendars={
+            "AAPL": {
+                "Earnings Date": ["2026-02-01"],
+                "Earnings Average": 1.5,
+                "Earnings High": 1.8,
+                "Earnings Low": 1.2,
+                "Revenue Average": 1000,
+                "Revenue High": 1100,
+                "Revenue Low": 900,
+            }
+        },
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_analyst_consensus",
+        symbol="AAPL",
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["symbol"] == "AAPL"
+    assert data["analyst_count"] == 19
+
+    recs = data["analyst_recommendations"]
+    assert recs["strong_buy"] == 5
+    assert recs["buy"] == 10
+    assert recs["total_analysts"] == 19
+    # strongBuy (5) is not > 50% of 19, but strongBuy+buy (15) is -> "Buy"
+    assert recs["consensus"] == "Buy"
+
+    target = data["target_price"]
+    assert target["current_price"] == 100.0
+    assert target["target_mean"] == 120.0
+    assert target["upside_potential_pct"] == 20.0
+
+    earnings = data["earnings_estimates"]
+    assert earnings["earnings_date"] == "2026-02-01"
+    assert earnings["earnings_average"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_get_analyst_consensus_strong_buy_consensus(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """A dominant strongBuy count yields a "Strong Buy" consensus label."""
+    recommendations = pd.DataFrame(
+        [{"strongBuy": 8, "buy": 1, "hold": 1, "sell": 0, "strongSell": 0}]
+    )
+    patch_ticker(
+        infos={"AAPL": {"regularMarketPrice": 50.0, "targetMeanPrice": 60.0}},
+        recommendations={"AAPL": recommendations},
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_analyst_consensus",
+        symbol="AAPL",
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["analyst_recommendations"]["consensus"] == "Strong Buy"
+    # current_price falls back to regularMarketPrice when currentPrice is absent
+    assert data["target_price"]["current_price"] == 50.0
+    assert data["target_price"]["upside_potential_pct"] == 20.0
+
+
+@pytest.mark.asyncio
+async def test_get_analyst_consensus_minimal_info(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """Missing recommendations/calendar yield empty sub-objects, not failures."""
+    patch_ticker(
+        infos={"NVDA": {"currentPrice": 200.0}},
+        recommendations={"NVDA": None},
+        calendars={"NVDA": None},
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_analyst_consensus",
+        symbol="NVDA",
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["analyst_recommendations"] == {}
+    assert data["earnings_estimates"] == {}
+    # No target_mean -> no upside computed
+    assert "upside_potential_pct" not in data["target_price"]
+    assert data["target_price"]["current_price"] == 200.0
+
+
+@pytest.mark.asyncio
+async def test_get_analyst_consensus_invalid_symbol_raises(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """An invalid symbol is rejected before any yfinance access."""
+    patch_ticker(infos={})
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "get_analyst_consensus",
+            symbol="",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_analyst_consensus_yfinance_failure_wrapped(
+    test_mcp: FastMCP, patch_ticker: Callable[..., None]
+) -> None:
+    """An error reading ``ticker.info`` is wrapped into a YahooFinanceError."""
+    patch_ticker(infos={"AAPL": RuntimeError("info unavailable")})
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "get_analyst_consensus",
+            symbol="AAPL",
+            ctx=None,
+        )

--- a/tests/mcp/test_market_comparison.py
+++ b/tests/mcp/test_market_comparison.py
@@ -97,11 +97,15 @@ def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
         recommendations: dict[str, Any] | None = None,
         calendars: dict[str, Any] | None = None,
     ) -> None:
-        monkeypatch.setattr(FakeTicker, "histories", histories or {})
-        monkeypatch.setattr(FakeTicker, "infos", infos or {})
-        monkeypatch.setattr(FakeTicker, "recommendations_data", recommendations or {})
-        monkeypatch.setattr(FakeTicker, "calendars", calendars or {})
-        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+        # Use a fresh per-call subclass so concurrent tests never share state.
+        class LocalFakeTicker(FakeTicker):
+            pass
+
+        LocalFakeTicker.histories = histories or {}
+        LocalFakeTicker.infos = infos or {}
+        LocalFakeTicker.recommendations_data = recommendations or {}
+        LocalFakeTicker.calendars = calendars or {}
+        monkeypatch.setattr(PATCH_TARGET, LocalFakeTicker)
 
     return _apply
 

--- a/tests/mcp/test_options.py
+++ b/tests/mcp/test_options.py
@@ -1,0 +1,577 @@
+"""Tests for options analysis MCP tools.
+
+These tests register the options tools on a real :class:`fastmcp.FastMCP`
+instance and invoke them through the FastMCP tool API so the production code
+path is exercised (and recorded by coverage). All yfinance/network access is
+mocked via a ``FakeTicker`` patched over ``yfinance.Ticker`` (the module does
+``import yfinance as yf`` inside each tool), so the suite is fully
+network-independent.
+
+Every tool in :mod:`ib_sec_mcp.mcp.tools.options` wraps its body in
+``try/except`` and returns ``{"error": ...}`` JSON on failure; none of them
+raise. Tests therefore assert the actual error-JSON behaviour rather than
+expecting raised exceptions.
+"""
+
+import json
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import Any, NamedTuple
+
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.tools.options import register_options_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+PATCH_TARGET = "yfinance.Ticker"
+
+
+class OptionChain(NamedTuple):
+    """Mimic yfinance ``Options`` result with ``.calls`` / ``.puts`` frames."""
+
+    calls: pd.DataFrame
+    puts: pd.DataFrame
+
+
+def make_option_frame(
+    strikes: list[float],
+    *,
+    volumes: list[int] | None = None,
+    open_interest: list[int] | None = None,
+    last_prices: list[float] | None = None,
+    ivs: list[float] | None = None,
+) -> pd.DataFrame:
+    """Build a realistic options DataFrame with the columns the tools access.
+
+    Columns mirror the yfinance ``option_chain`` schema accessed by the source:
+    ``strike``, ``lastPrice``, ``bid``, ``ask``, ``volume``, ``openInterest``,
+    ``impliedVolatility``, ``inTheMoney``, ``contractSymbol``.
+    """
+    n = len(strikes)
+    volumes = volumes if volumes is not None else [100] * n
+    open_interest = open_interest if open_interest is not None else [500] * n
+    last_prices = last_prices if last_prices is not None else [1.0] * n
+    ivs = ivs if ivs is not None else [0.30] * n
+
+    return pd.DataFrame(
+        {
+            "contractSymbol": [f"OPT{int(s)}" for s in strikes],
+            "strike": strikes,
+            "lastPrice": last_prices,
+            "bid": [p - 0.05 for p in last_prices],
+            "ask": [p + 0.05 for p in last_prices],
+            "volume": volumes,
+            "openInterest": open_interest,
+            "impliedVolatility": ivs,
+            "inTheMoney": [False] * n,
+        }
+    )
+
+
+def _future_expiry(days: int = 30) -> str:
+    """Return a future expiration date string in YYYY-MM-DD format."""
+    return (datetime.now() + timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+class FakeTicker:
+    """yfinance ticker fake backed by class-level per-symbol payloads.
+
+    Each payload is a dict with optional keys:
+    ``options`` (tuple of expiry strings), ``chains`` (mapping expiry -> chain
+    or a single chain used for any expiry), ``info`` (dict), ``history``
+    (DataFrame). An ``Exception`` value anywhere triggers that error to surface
+    when the corresponding attribute/method is accessed.
+    """
+
+    payloads: dict[str, Any] = {}
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+        payload = self.payloads[symbol]
+        if isinstance(payload, Exception):
+            raise payload
+        self._payload = payload
+
+    @property
+    def options(self) -> tuple[str, ...]:
+        value = self._payload.get("options", ())
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def option_chain(self, expiry: str) -> OptionChain:
+        chains = self._payload.get("chains")
+        if isinstance(chains, Exception):
+            raise chains
+        if isinstance(chains, OptionChain):
+            return chains
+        if isinstance(chains, dict):
+            return chains[expiry]
+        raise ValueError("no chain configured")
+
+    @property
+    def info(self) -> dict[str, Any]:
+        value = self._payload.get("info", {})
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def history(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
+        value = self._payload.get("history", pd.DataFrame())
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with the options tools registered."""
+    mcp = FastMCP("test")
+    register_options_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[[dict[str, Any]], None]:
+    """Return a helper that installs FakeTicker with the given per-symbol payloads."""
+
+    def _apply(payloads: dict[str, Any]) -> None:
+        monkeypatch.setattr(FakeTicker, "payloads", payloads)
+        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+
+    return _apply
+
+
+# ---------------------------------------------------------------------------
+# get_options_chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_options_chain_returns_expected_keys(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A valid chain yields calls/puts records and an aggregated summary."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([90.0, 100.0], volumes=[10, 20], open_interest=[100, 200]),
+        puts=make_option_frame([90.0, 100.0], volumes=[5, 15], open_interest=[50, 150]),
+    )
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "get_options_chain", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data["symbol"] == "SPY"
+    assert data["expiration_date"] == exp
+    assert data["available_expirations"] == [exp]
+    assert len(data["calls"]) == 2
+    assert len(data["puts"]) == 2
+    summary = data["summary"]
+    assert summary["num_calls"] == 2
+    assert summary["num_puts"] == 2
+    assert summary["total_call_volume"] == 30
+    assert summary["total_put_volume"] == 20
+    assert summary["total_call_oi"] == 300
+    assert summary["total_put_oi"] == 200
+
+
+@pytest.mark.asyncio
+async def test_get_options_chain_no_options_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """An empty ``.options`` tuple yields a graceful error payload (no raise)."""
+    patch_ticker({"NOPT": {"options": ()}})
+
+    result = await call_tool_fn(test_mcp, "get_options_chain", symbol="NOPT", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "No options data available for NOPT"}
+
+
+@pytest.mark.asyncio
+async def test_get_options_chain_invalid_expiration_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """An expiration not in the available list returns an error payload."""
+    exp = _future_expiry()
+    chain = OptionChain(calls=make_option_frame([100.0]), puts=make_option_frame([100.0]))
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {}}})
+
+    result = await call_tool_fn(
+        test_mcp, "get_options_chain", symbol="SPY", expiration_date="1999-01-01", ctx=None
+    )
+    data = json.loads(result)
+
+    assert "error" in data
+    assert "Invalid expiration date" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_options_chain_yfinance_raises_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A yfinance failure is caught and surfaced as an error payload."""
+    patch_ticker({"BOOM": RuntimeError("network down")})
+
+    result = await call_tool_fn(test_mcp, "get_options_chain", symbol="BOOM", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "network down"}
+
+
+# ---------------------------------------------------------------------------
+# calculate_put_call_ratio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_call_ratio_open_interest(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Open-interest PCR is put OI / call OI with a bearish interpretation."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([95.0, 105.0], volumes=[40, 60], open_interest=[100, 100]),
+        puts=make_option_frame([95.0, 105.0], volumes=[80, 70], open_interest=[150, 150]),
+    )
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_put_call_ratio", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    # put OI = 300, call OI = 200 -> 1.5
+    assert data["put_call_ratio"] == 1.5
+    assert data["ratio_type"] == "open_interest"
+    assert data["interpretation"].startswith("Bearish")
+    assert data["details"]["total_puts"] == 300
+    assert data["details"]["total_calls"] == 200
+    # ATM strike: nearest to 100.0 among [95, 105] -> 95 (abs tie broken low)
+    assert data["strike_distribution"]["atm_strike"] in (95.0, 105.0)
+
+
+@pytest.mark.asyncio
+async def test_put_call_ratio_volume(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Volume PCR divides put volume by call volume."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([100.0], volumes=[200], open_interest=[10]),
+        puts=make_option_frame([100.0], volumes=[100], open_interest=[10]),
+    )
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(
+        test_mcp, "calculate_put_call_ratio", symbol="SPY", ratio_type="volume", ctx=None
+    )
+    data = json.loads(result)
+
+    # put vol 100 / call vol 200 = 0.5 -> Bullish (< 0.7)
+    assert data["put_call_ratio"] == 0.5
+    assert data["ratio_type"] == "volume"
+    assert data["interpretation"].startswith("Bullish")
+
+
+@pytest.mark.asyncio
+async def test_put_call_ratio_zero_calls_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Zero call total yields an explicit error (avoids division by zero)."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([100.0], volumes=[0], open_interest=[0]),
+        puts=make_option_frame([100.0], volumes=[10], open_interest=[10]),
+    )
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_put_call_ratio", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "Call total is zero, cannot calculate ratio"}
+
+
+@pytest.mark.asyncio
+async def test_put_call_ratio_no_options_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Empty options tuple yields a graceful error payload."""
+    patch_ticker({"NOPT": {"options": ()}})
+
+    result = await call_tool_fn(test_mcp, "calculate_put_call_ratio", symbol="NOPT", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "No options data available for NOPT"}
+
+
+# ---------------------------------------------------------------------------
+# calculate_greeks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_calculate_greeks_returns_all_greeks(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Greeks are computed for every strike with sane ATM values."""
+    exp = _future_expiry(30)
+    strikes = [90.0, 100.0, 110.0]
+    chain = OptionChain(
+        calls=make_option_frame(strikes, open_interest=[100, 100, 100], ivs=[0.25, 0.25, 0.25]),
+        puts=make_option_frame(strikes, open_interest=[100, 100, 100], ivs=[0.25, 0.25, 0.25]),
+    )
+    patch_ticker({"AAPL": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_greeks", symbol="AAPL", ctx=None)
+    data = json.loads(result)
+
+    assert data["symbol"] == "AAPL"
+    assert data["current_price"] == 100.0
+    assert data["expiration_date"] == exp
+    assert data["atm_strike"] == 100.0
+
+    call_greek = data["atm_greeks"]["call"]
+    put_greek = data["atm_greeks"]["put"]
+    for key in ("strike", "delta", "gamma", "theta", "vega", "rho", "implied_volatility"):
+        assert key in call_greek
+        assert key in put_greek
+
+    # ATM call delta is roughly 0.5; put delta roughly -0.5; gamma/vega positive.
+    assert 0.4 < call_greek["delta"] < 0.7
+    assert -0.7 < put_greek["delta"] < -0.3
+    assert call_greek["gamma"] > 0
+    assert call_greek["vega"] > 0
+    assert call_greek["theta"] < 0  # time decay
+
+    assert len(data["all_strikes"]["calls"]) == 3
+    assert len(data["all_strikes"]["puts"]) == 3
+    assert "net_delta" in data["summary"]
+
+
+@pytest.mark.asyncio
+async def test_calculate_greeks_defaults_missing_iv(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A zero/NaN IV is replaced by the 30% default, so Greeks stay finite."""
+    exp = _future_expiry(45)
+    chain = OptionChain(
+        calls=make_option_frame([100.0], open_interest=[10], ivs=[0.0]),
+        puts=make_option_frame([100.0], open_interest=[10], ivs=[0.0]),
+    )
+    patch_ticker(
+        {"AAPL": {"options": (exp,), "chains": chain, "info": {"regularMarketPrice": 100.0}}}
+    )
+
+    result = await call_tool_fn(test_mcp, "calculate_greeks", symbol="AAPL", ctx=None)
+    data = json.loads(result)
+
+    assert data["atm_greeks"]["call"]["implied_volatility"] == 0.3
+
+
+@pytest.mark.asyncio
+async def test_calculate_greeks_no_price_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Missing current price yields an error payload."""
+    exp = _future_expiry()
+    chain = OptionChain(calls=make_option_frame([100.0]), puts=make_option_frame([100.0]))
+    patch_ticker({"AAPL": {"options": (exp,), "chains": chain, "info": {}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_greeks", symbol="AAPL", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "Could not fetch current stock price"}
+
+
+@pytest.mark.asyncio
+async def test_calculate_greeks_no_options_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Empty options tuple yields a graceful error payload."""
+    patch_ticker({"NOPT": {"options": ()}})
+
+    result = await call_tool_fn(test_mcp, "calculate_greeks", symbol="NOPT", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "No options data available for NOPT"}
+
+
+# ---------------------------------------------------------------------------
+# calculate_iv_metrics
+# ---------------------------------------------------------------------------
+
+
+def _history_frame(prices: list[float]) -> pd.DataFrame:
+    """Build a minimal history frame with a ``Close`` column."""
+    return pd.DataFrame({"Close": prices})
+
+
+@pytest.mark.asyncio
+async def test_calculate_iv_metrics_returns_metrics(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """IV metrics include the rank/percentile keys and the proxy ``note``."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([95.0, 100.0, 105.0], ivs=[0.20, 0.35, 0.40]),
+        puts=make_option_frame([95.0, 100.0, 105.0], ivs=[0.20, 0.35, 0.40]),
+    )
+    # 60 trading days of mildly varying closes -> non-degenerate rolling vol.
+    prices = [100.0 + (i % 7) - 3 for i in range(60)]
+    patch_ticker(
+        {
+            "SPY": {
+                "options": (exp,),
+                "chains": chain,
+                "info": {"currentPrice": 100.0},
+                "history": _history_frame(prices),
+            }
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "calculate_iv_metrics", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data["symbol"] == "SPY"
+    assert data["current_price"] == 100.0
+    # ATM strike is 100.0 with IV 0.35 -> current_iv reported as 35.0%.
+    assert data["current_iv"] == 35.0
+    for key in (
+        "iv_rank",
+        "iv_percentile",
+        "iv_52week_high",
+        "iv_52week_low",
+        "iv_52week_mean",
+        "interpretation",
+        "lookback_days",
+        "note",
+    ):
+        assert key in data
+    assert "proxy" in data["note"]
+    assert 0 <= data["iv_percentile"] <= 100
+
+
+@pytest.mark.asyncio
+async def test_calculate_iv_metrics_insufficient_history_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Fewer than 20 history rows yields an insufficient-data error."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([100.0], ivs=[0.30]),
+        puts=make_option_frame([100.0], ivs=[0.30]),
+    )
+    patch_ticker(
+        {
+            "SPY": {
+                "options": (exp,),
+                "chains": chain,
+                "info": {"currentPrice": 100.0},
+                "history": _history_frame([100.0] * 5),
+            }
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "calculate_iv_metrics", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "Insufficient historical data"}
+
+
+@pytest.mark.asyncio
+async def test_calculate_iv_metrics_zero_iv_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A zero ATM IV yields an explicit error before history is consulted."""
+    exp = _future_expiry()
+    chain = OptionChain(
+        calls=make_option_frame([100.0], ivs=[0.0]),
+        puts=make_option_frame([100.0], ivs=[0.0]),
+    )
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_iv_metrics", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "Could not fetch current implied volatility"}
+
+
+# ---------------------------------------------------------------------------
+# calculate_max_pain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_calculate_max_pain_deterministic_strike(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Max pain is the strike minimising total writer payout for a crafted OI."""
+    exp = _future_expiry(7)
+    strikes = [90.0, 100.0, 110.0]
+    # Heavy call OI at 90 and heavy put OI at 110 push max pain to the middle (100).
+    chain = OptionChain(
+        calls=make_option_frame(
+            strikes, open_interest=[1000, 10, 10], last_prices=[12.0, 5.0, 1.0]
+        ),
+        puts=make_option_frame(strikes, open_interest=[10, 10, 1000], last_prices=[1.0, 5.0, 12.0]),
+    )
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_max_pain", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data["symbol"] == "SPY"
+    assert data["expiration_date"] == exp
+    assert data["max_pain_strike"] == 100.0
+    assert data["current_price"] == 100.0
+    assert data["distance_to_max_pain"] == 0.0
+    assert "pain_by_strike" in data
+    assert set(data["pain_by_strike"].keys()) == {"90.0", "100.0", "110.0"}
+    assert len(data["top_pain_strikes"]) == 3
+    # ATM straddle expected move from last prices at strike 100 (5 + 5).
+    assert data["expected_move"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_calculate_max_pain_no_price_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Missing current price yields an error payload."""
+    exp = _future_expiry()
+    chain = OptionChain(calls=make_option_frame([100.0]), puts=make_option_frame([100.0]))
+    patch_ticker({"SPY": {"options": (exp,), "chains": chain, "info": {}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_max_pain", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "Could not fetch current stock price"}
+
+
+@pytest.mark.asyncio
+async def test_calculate_max_pain_no_future_expiration_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """When all expirations are in the past, an explicit error is returned."""
+    past = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+    chain = OptionChain(calls=make_option_frame([100.0]), puts=make_option_frame([100.0]))
+    patch_ticker({"SPY": {"options": (past,), "chains": chain, "info": {"currentPrice": 100.0}}})
+
+    result = await call_tool_fn(test_mcp, "calculate_max_pain", symbol="SPY", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "No future expiration dates available"}
+
+
+@pytest.mark.asyncio
+async def test_calculate_max_pain_no_options_returns_error(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Empty options tuple yields a graceful error payload."""
+    patch_ticker({"NOPT": {"options": ()}})
+
+    result = await call_tool_fn(test_mcp, "calculate_max_pain", symbol="NOPT", ctx=None)
+    data = json.loads(result)
+
+    assert data == {"error": "No options data available for NOPT"}

--- a/tests/mcp/test_options.py
+++ b/tests/mcp/test_options.py
@@ -138,8 +138,12 @@ def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[[dict[str, Any]], 
     """Return a helper that installs FakeTicker with the given per-symbol payloads."""
 
     def _apply(payloads: dict[str, Any]) -> None:
-        monkeypatch.setattr(FakeTicker, "payloads", payloads)
-        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+        # Use a fresh per-call subclass so concurrent tests never share state.
+        class LocalFakeTicker(FakeTicker):
+            pass
+
+        LocalFakeTicker.payloads = payloads
+        monkeypatch.setattr(PATCH_TARGET, LocalFakeTicker)
 
     return _apply
 

--- a/tests/mcp/test_stock_data.py
+++ b/tests/mcp/test_stock_data.py
@@ -102,13 +102,17 @@ def patch_ticker(monkeypatch: pytest.MonkeyPatch):
         info_data: dict[str, Any] | Exception | None = None,
         dividends_data: pd.Series | Exception | None = None,
     ) -> None:
-        monkeypatch.setattr(FakeTicker, "history_data", history_data)
-        monkeypatch.setattr(FakeTicker, "history_error", history_error)
+        # Use a fresh per-call subclass so concurrent tests never share state.
+        class LocalFakeTicker(FakeTicker):
+            pass
+
+        LocalFakeTicker.history_data = history_data
+        LocalFakeTicker.history_error = history_error
         if info_data is not None:
-            monkeypatch.setattr(FakeTicker, "info_data", info_data)
+            LocalFakeTicker.info_data = info_data
         if dividends_data is not None:
-            monkeypatch.setattr(FakeTicker, "dividends_data", dividends_data)
-        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+            LocalFakeTicker.dividends_data = dividends_data
+        monkeypatch.setattr(PATCH_TARGET, LocalFakeTicker)
 
     return _apply
 

--- a/tests/mcp/test_stock_data.py
+++ b/tests/mcp/test_stock_data.py
@@ -1,0 +1,419 @@
+"""Tests for stock data MCP tools.
+
+These tests register the tools on a real :class:`fastmcp.FastMCP` instance and
+invoke them through the FastMCP tool API so that the production code path is
+exercised (and recorded by coverage). All yfinance access is mocked, so the
+suite is network-independent.
+
+Note on patch target: ``stock_data.py`` performs ``import yfinance as yf``
+*inside* the tool functions, so the real module attribute ``yfinance.Ticker``
+must be patched (not a module-level ``yf`` alias).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import IBTimeoutError, ValidationError, YahooFinanceError
+from ib_sec_mcp.mcp.tools.stock_data import register_stock_data_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+PATCH_TARGET = "yfinance.Ticker"
+
+
+def _make_history(rows: int = 250) -> pd.DataFrame:
+    """Build a deterministic OHLCV DataFrame with a DatetimeIndex.
+
+    Prices increase monotonically so indicators have non-NaN latest values once
+    ``rows`` exceeds the longest window (200 for sma_200).
+    """
+    index = pd.date_range(start="2024-01-01", periods=rows, freq="D")
+    close = [100.0 + i for i in range(rows)]
+    data = {
+        "Open": [c - 0.5 for c in close],
+        "High": [c + 1.0 for c in close],
+        "Low": [c - 1.0 for c in close],
+        "Close": close,
+        "Volume": [1_000_000 + i * 1_000 for i in range(rows)],
+    }
+    return pd.DataFrame(data, index=index)
+
+
+class FakeTicker:
+    """yfinance ticker fake backed by class-level fixtures.
+
+    ``history_data`` / ``history_error`` drive ``get_stock_data``; ``info`` and
+    ``dividends`` drive ``get_current_price`` / ``get_stock_info``. Errors stored
+    on these attributes are raised when accessed.
+    """
+
+    history_data: pd.DataFrame | None = None
+    history_error: Exception | None = None
+    info_data: dict[str, Any] | Exception = {}
+    dividends_data: pd.Series | Exception = pd.Series(dtype="float64")
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def history(self, period: str = "1mo", interval: str = "1d") -> pd.DataFrame:
+        if self.history_error is not None:
+            raise self.history_error
+        assert self.history_data is not None
+        return self.history_data
+
+    @property
+    def info(self) -> dict[str, Any]:
+        if isinstance(self.info_data, Exception):
+            raise self.info_data
+        return self.info_data
+
+    @property
+    def dividends(self) -> pd.Series:
+        if isinstance(self.dividends_data, Exception):
+            raise self.dividends_data
+        return self.dividends_data
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with the stock data tools registered."""
+    mcp = FastMCP("test")
+    register_stock_data_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_ticker(monkeypatch: pytest.MonkeyPatch):
+    """Install FakeTicker and configure its class-level fixtures.
+
+    ``monkeypatch.setattr`` restores all attributes after each test, preventing
+    cross-test state pollution.
+    """
+
+    def _apply(
+        *,
+        history_data: pd.DataFrame | None = None,
+        history_error: Exception | None = None,
+        info_data: dict[str, Any] | Exception | None = None,
+        dividends_data: pd.Series | Exception | None = None,
+    ) -> None:
+        monkeypatch.setattr(FakeTicker, "history_data", history_data)
+        monkeypatch.setattr(FakeTicker, "history_error", history_error)
+        if info_data is not None:
+            monkeypatch.setattr(FakeTicker, "info_data", info_data)
+        if dividends_data is not None:
+            monkeypatch.setattr(FakeTicker, "dividends_data", dividends_data)
+        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+
+    return _apply
+
+
+# ---------------------------------------------------------------------------
+# get_stock_data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_happy_path(test_mcp: FastMCP, patch_ticker) -> None:
+    """Valid request returns expected top-level keys and summary fields."""
+    patch_ticker(history_data=_make_history(250))
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_stock_data",
+        symbol="VOO",
+        period="1y",
+        interval="1d",
+        ctx=None,
+    )
+    parsed = json.loads(result)
+
+    assert parsed["symbol"] == "VOO"
+    assert parsed["period"] == "1y"
+    assert parsed["interval"] == "1d"
+
+    summary = parsed["summary"]
+    for key in (
+        "latest_close",
+        "period_high",
+        "period_low",
+        "period_return",
+        "avg_volume",
+    ):
+        assert key in summary
+
+    # data present when summary_only is False (default)
+    assert "data" in parsed
+    assert parsed["summary"]["latest_close"] == 349.0
+    assert parsed["summary"]["period_high"] == 350.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_with_indicators(test_mcp: FastMCP, patch_ticker) -> None:
+    """Requested indicators appear under technical_indicators."""
+    patch_ticker(history_data=_make_history(250))
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_stock_data",
+        symbol="AAPL",
+        period="1y",
+        interval="1d",
+        indicators="sma_20,rsi,macd,bollinger,volume_ma,ema_12",
+        ctx=None,
+    )
+    parsed = json.loads(result)
+
+    indicators = parsed["technical_indicators"]
+    for key in ("sma_20", "rsi", "macd", "bollinger", "volume_ma", "ema_12"):
+        assert key in indicators
+
+    # With 250 monotonic rows the latest values are non-NaN (not None).
+    assert indicators["sma_20"]["latest"] is not None
+    assert indicators["rsi"]["latest"] is not None
+    assert indicators["macd"]["macd"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_summary_only(test_mcp: FastMCP, patch_ticker) -> None:
+    """summary_only=True omits the detailed data array."""
+    patch_ticker(history_data=_make_history(250))
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_stock_data",
+        symbol="VOO",
+        summary_only=True,
+        ctx=None,
+    )
+    parsed = json.loads(result)
+
+    assert "data" not in parsed
+    assert parsed["summary"]["num_records_returned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_limit(test_mcp: FastMCP, patch_ticker) -> None:
+    """limit=N returns only the latest N records."""
+    patch_ticker(history_data=_make_history(250))
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_stock_data",
+        symbol="VOO",
+        limit=5,
+        ctx=None,
+    )
+    parsed = json.loads(result)
+
+    assert parsed["summary"]["num_records_returned"] == 5
+    assert len(parsed["data"]) == 5
+    # num_records reflects the full unlimited dataset.
+    assert parsed["summary"]["num_records"] == 250
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_short_history_nan_indicators(test_mcp: FastMCP, patch_ticker) -> None:
+    """Indicators needing more rows than available yield None latest values."""
+    patch_ticker(history_data=_make_history(5))
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_stock_data",
+        symbol="VOO",
+        indicators="sma_20",
+        ctx=None,
+    )
+    parsed = json.loads(result)
+
+    # 5 rows < 20-day window -> rolling mean latest is NaN -> serialized None.
+    assert parsed["technical_indicators"]["sma_20"]["latest"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_invalid_symbol_raises(test_mcp: FastMCP, patch_ticker) -> None:
+    """An invalid symbol raises ValidationError before any yfinance access."""
+    patch_ticker(history_data=_make_history(250))
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_data",
+            symbol="!!bad!!",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_empty_dataframe_raises(test_mcp: FastMCP, patch_ticker) -> None:
+    """An empty DataFrame raises YahooFinanceError ('No data found')."""
+    patch_ticker(history_data=pd.DataFrame())
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_data",
+            symbol="VOO",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_history_exception_raises(test_mcp: FastMCP, patch_ticker) -> None:
+    """An exception inside history() is wrapped as YahooFinanceError."""
+    patch_ticker(history_error=RuntimeError("yfinance boom"))
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_data",
+            symbol="VOO",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_data_timeout_in_history_raises_timeout(
+    test_mcp: FastMCP, patch_ticker
+) -> None:
+    """A TimeoutError raised by history() is caught first and becomes IBTimeoutError.
+
+    The source's ``except TimeoutError`` precedes ``except Exception``, so a
+    ``TimeoutError`` propagating from ``history()`` is wrapped as
+    ``IBTimeoutError`` (asserting actual behavior, not the broader except).
+    """
+    patch_ticker(history_error=TimeoutError("slow"))
+
+    with pytest.raises(IBTimeoutError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_data",
+            symbol="VOO",
+            ctx=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_current_price
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_happy_path(test_mcp: FastMCP, patch_ticker) -> None:
+    """Returns current_price from currentPrice when present."""
+    patch_ticker(
+        info_data={
+            "currentPrice": 350.25,
+            "regularMarketPrice": 349.0,
+            "previousClose": 348.0,
+            "volume": 1_234_567,
+            "marketCap": 1_000_000_000,
+            "trailingPE": 25.5,
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "get_current_price", symbol="VOO", ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["symbol"] == "VOO"
+    assert parsed["current_price"] == 350.25
+    assert parsed["previous_close"] == 348.0
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_falls_back_to_regular_market_price(
+    test_mcp: FastMCP, patch_ticker
+) -> None:
+    """current_price falls back to regularMarketPrice when currentPrice missing."""
+    patch_ticker(
+        info_data={
+            "regularMarketPrice": 349.0,
+            "previousClose": 348.0,
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "get_current_price", symbol="VOO", ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["current_price"] == 349.0
+
+
+@pytest.mark.asyncio
+async def test_get_current_price_exception_returns_error(test_mcp: FastMCP, patch_ticker) -> None:
+    """A yfinance failure is caught and returned as an error JSON (no raise)."""
+    patch_ticker(info_data=RuntimeError("info failed"))
+
+    result = await call_tool_fn(test_mcp, "get_current_price", symbol="VOO", ctx=None)
+    parsed = json.loads(result)
+
+    assert "error" in parsed
+    assert parsed["error"] == "info failed"
+
+
+# ---------------------------------------------------------------------------
+# get_stock_info
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_stock_info_happy_path(test_mcp: FastMCP, patch_ticker) -> None:
+    """Returns nested sections with dividends populated from the dividends Series."""
+    dividends = pd.Series(
+        [1.0, 1.1, 1.2],
+        index=pd.date_range("2025-01-01", periods=3, freq="QE"),
+    )
+    patch_ticker(
+        info_data={
+            "longName": "Vanguard S&P 500 ETF",
+            "shortName": "VOO",
+            "sector": "Financial Services",
+            "marketCap": 1_000_000_000,
+            "trailingPE": 25.5,
+            "dividendRate": 4.5,
+            "dividendYield": 0.013,
+        },
+        dividends_data=dividends,
+    )
+
+    result = await call_tool_fn(test_mcp, "get_stock_info", symbol="VOO", ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["symbol"] == "VOO"
+    assert parsed["basic_info"]["long_name"] == "Vanguard S&P 500 ETF"
+    assert parsed["valuation_metrics"]["market_cap"] == 1_000_000_000
+
+    recent = parsed["dividend_info"]["recent_dividends"]
+    assert len(recent) == 3
+    assert recent[0]["amount"] == 1.0
+    assert "date" in recent[0]
+
+
+@pytest.mark.asyncio
+async def test_get_stock_info_empty_dividends(test_mcp: FastMCP, patch_ticker) -> None:
+    """An empty dividends Series yields an empty recent_dividends list."""
+    patch_ticker(
+        info_data={"longName": "No Div Corp"},
+        dividends_data=pd.Series(dtype="float64"),
+    )
+
+    result = await call_tool_fn(test_mcp, "get_stock_info", symbol="NODIV", ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["dividend_info"]["recent_dividends"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_stock_info_exception_returns_error(test_mcp: FastMCP, patch_ticker) -> None:
+    """A yfinance failure is caught and returned as an error JSON (no raise)."""
+    patch_ticker(info_data=RuntimeError("info exploded"))
+
+    result = await call_tool_fn(test_mcp, "get_stock_info", symbol="VOO", ctx=None)
+    parsed = json.loads(result)
+
+    assert "error" in parsed
+    assert parsed["error"] == "info exploded"

--- a/tests/mcp/test_stock_news.py
+++ b/tests/mcp/test_stock_news.py
@@ -1,0 +1,305 @@
+"""Tests for stock news MCP tools.
+
+These tests register the ``get_stock_news`` tool on a real
+:class:`fastmcp.FastMCP` instance and invoke it through the FastMCP tool API so
+that the production code path is exercised (and recorded by coverage). All
+yfinance access is mocked via ``monkeypatch.setattr("yfinance.Ticker", ...)``,
+so the suite is network-independent.
+"""
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import ValidationError, YahooFinanceError
+from ib_sec_mcp.mcp.tools.stock_news import register_stock_news_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+
+class FakeTicker:
+    """yfinance ticker fake backed by per-symbol news payloads.
+
+    ``stock_news`` performs ``import yfinance as yf`` inside the tool and reads
+    ``ticker.news``. The class attribute is swapped per test via monkeypatch.
+    """
+
+    news_by_symbol: dict[str, Any] = {}
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    @property
+    def news(self) -> Any:
+        value = self.news_by_symbol[self.symbol]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with the stock news tool registered."""
+    mcp = FastMCP("test")
+    register_stock_news_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[[dict[str, Any]], None]:
+    """Return a helper installing FakeTicker with the given per-symbol news.
+
+    Patches ``yfinance.Ticker`` directly because the tool imports yfinance
+    lazily inside the function body.
+    """
+
+    def _apply(news_by_symbol: dict[str, Any]) -> None:
+        monkeypatch.setattr(FakeTicker, "news_by_symbol", news_by_symbol)
+        monkeypatch.setattr("yfinance.Ticker", FakeTicker)
+
+    return _apply
+
+
+def _nested_article(
+    title: str,
+    publisher: str,
+    url: str,
+    pub_date: str,
+    summary: str = "",
+    content_type: str = "STORY",
+) -> dict[str, Any]:
+    """Build an article using yfinance's nested ``content`` shape."""
+    return {
+        "content": {
+            "title": title,
+            "provider": {"displayName": publisher},
+            "canonicalUrl": {"url": url},
+            "pubDate": pub_date,
+            "contentType": content_type,
+            "summary": summary,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_nested_content_mapping(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Nested ``content`` articles map onto the documented article fields."""
+    patch_ticker(
+        {
+            "AAPL": [
+                _nested_article(
+                    title="Apple unveils new chip",
+                    publisher="Reuters",
+                    url="https://example.com/apple-chip",
+                    pub_date="2026-01-02T10:00:00Z",
+                    summary="A summary of the chip launch.",
+                    content_type="STORY",
+                )
+            ]
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=10, ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["symbol"] == "AAPL"
+    assert parsed["news_count"] == 1
+    assert "fetch_time" in parsed
+
+    article = parsed["articles"][0]
+    assert article["title"] == "Apple unveils new chip"
+    assert article["publisher"] == "Reuters"
+    assert article["link"] == "https://example.com/apple-chip"
+    assert article["publish_time"] == "2026-01-02T10:00:00Z"
+    assert article["type"] == "STORY"
+    assert article["summary"] == "A summary of the chip launch."
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_flat_fallback_shape(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Flat articles (no ``content`` key) fall back to top-level fields."""
+    patch_ticker(
+        {
+            "TSLA": [
+                {
+                    "title": "Tesla flat-shape headline",
+                    "provider": {"displayName": "Bloomberg"},
+                    # No canonicalUrl -> link fallback is exercised.
+                    "link": "https://example.com/tesla-flat",
+                    "pubDate": "2026-01-03T08:00:00Z",
+                    "contentType": "VIDEO",
+                    "summary": "Flat summary.",
+                }
+            ]
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="TSLA", limit=10, ctx=None)
+    parsed = json.loads(result)
+
+    article = parsed["articles"][0]
+    assert article["title"] == "Tesla flat-shape headline"
+    assert article["publisher"] == "Bloomberg"
+    assert article["link"] == "https://example.com/tesla-flat"
+    assert article["publish_time"] == "2026-01-03T08:00:00Z"
+    assert article["type"] == "VIDEO"
+    assert article["summary"] == "Flat summary."
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_missing_fields_use_defaults(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Articles missing fields fall back to documented default values."""
+    patch_ticker({"AAPL": [{"content": {}}]})
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=10, ctx=None)
+    parsed = json.loads(result)
+
+    article = parsed["articles"][0]
+    assert article["title"] == "N/A"
+    assert article["publisher"] == "Unknown"
+    assert article["link"] == ""
+    assert article["publish_time"] == "N/A"
+    assert article["type"] == "STORY"
+    assert article["summary"] == ""
+    assert "thumbnail_url" not in article
+    assert "related_tickers" not in article
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_thumbnail_and_related_tickers(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Thumbnail resolutions and related tickers are surfaced when present."""
+    patch_ticker(
+        {
+            "AAPL": [
+                {
+                    "content": {
+                        "title": "With extras",
+                        "provider": {"displayName": "CNBC"},
+                        "canonicalUrl": {"url": "https://example.com/extras"},
+                        "pubDate": "2026-01-04T12:00:00Z",
+                        "contentType": "STORY",
+                        "summary": "Has thumbnail and related tickers.",
+                        "thumbnail": {
+                            "resolutions": [
+                                {"url": "https://img.example.com/large.jpg"},
+                                {"url": "https://img.example.com/small.jpg"},
+                            ]
+                        },
+                        "relatedTickers": ["AAPL", "MSFT"],
+                    }
+                }
+            ]
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=10, ctx=None)
+    parsed = json.loads(result)
+
+    article = parsed["articles"][0]
+    assert article["thumbnail_url"] == "https://img.example.com/large.jpg"
+    assert article["related_tickers"] == ["AAPL", "MSFT"]
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_related_tickers_from_top_level(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """``relatedTickers`` may live at the article top level, not in content."""
+    patch_ticker(
+        {
+            "AAPL": [
+                {
+                    "content": {
+                        "title": "Top-level related tickers",
+                        "provider": {"displayName": "WSJ"},
+                        "canonicalUrl": {"url": "https://example.com/top"},
+                        "pubDate": "2026-01-05T09:00:00Z",
+                        "contentType": "STORY",
+                        "summary": "",
+                    },
+                    "relatedTickers": ["GOOG"],
+                }
+            ]
+        }
+    )
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=10, ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["articles"][0]["related_tickers"] == ["GOOG"]
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_limit_caps_articles(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """The ``limit`` parameter caps the number of returned articles."""
+    articles = [
+        _nested_article(
+            title=f"Headline {i}",
+            publisher="Reuters",
+            url=f"https://example.com/{i}",
+            pub_date="2026-01-02T10:00:00Z",
+        )
+        for i in range(8)
+    ]
+    patch_ticker({"AAPL": articles})
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=3, ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["news_count"] == 3
+    assert len(parsed["articles"]) == 3
+    assert [a["title"] for a in parsed["articles"]] == ["Headline 0", "Headline 1", "Headline 2"]
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_empty_news_list(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """An empty news list yields a zero-count payload with a message."""
+    patch_ticker({"AAPL": []})
+
+    result = await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=10, ctx=None)
+    parsed = json.loads(result)
+
+    assert parsed["symbol"] == "AAPL"
+    assert parsed["news_count"] == 0
+    assert parsed["articles"] == []
+    assert "message" in parsed
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_invalid_symbol_raises(test_mcp: FastMCP) -> None:
+    """An invalid symbol is rejected before any yfinance access."""
+    with pytest.raises(ValidationError):
+        await call_tool_fn(test_mcp, "get_stock_news", symbol="!!bad!!", limit=10, ctx=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, 51, -1])
+async def test_get_stock_news_limit_out_of_range_raises(test_mcp: FastMCP, limit: int) -> None:
+    """A limit below 1 or above 50 raises a ValidationError."""
+    with pytest.raises(ValidationError):
+        await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=limit, ctx=None)
+
+
+@pytest.mark.asyncio
+async def test_get_stock_news_yfinance_failure_raises(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A yfinance error during news access surfaces as YahooFinanceError."""
+    patch_ticker({"AAPL": RuntimeError("yahoo is down")})
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(test_mcp, "get_stock_news", symbol="AAPL", limit=10, ctx=None)

--- a/tests/mcp/test_stock_news.py
+++ b/tests/mcp/test_stock_news.py
@@ -56,8 +56,12 @@ def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[[dict[str, Any]], 
     """
 
     def _apply(news_by_symbol: dict[str, Any]) -> None:
-        monkeypatch.setattr(FakeTicker, "news_by_symbol", news_by_symbol)
-        monkeypatch.setattr("yfinance.Ticker", FakeTicker)
+        # Use a fresh per-call subclass so concurrent tests never share state.
+        class LocalFakeTicker(FakeTicker):
+            pass
+
+        LocalFakeTicker.news_by_symbol = news_by_symbol
+        monkeypatch.setattr("yfinance.Ticker", LocalFakeTicker)
 
     return _apply
 

--- a/tests/mcp/test_technical_analysis.py
+++ b/tests/mcp/test_technical_analysis.py
@@ -101,8 +101,12 @@ def patch_history(
     """Install FakeTicker with the given ``history`` payload for the test."""
 
     def _apply(history_result: object) -> None:
-        monkeypatch.setattr(FakeTicker, "history_result", history_result)
-        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+        # Use a fresh per-call subclass so concurrent tests never share state.
+        class LocalFakeTicker(FakeTicker):
+            pass
+
+        LocalFakeTicker.history_result = history_result
+        monkeypatch.setattr(PATCH_TARGET, LocalFakeTicker)
 
     return _apply
 

--- a/tests/mcp/test_technical_analysis.py
+++ b/tests/mcp/test_technical_analysis.py
@@ -1,0 +1,561 @@
+"""Tests for advanced technical analysis MCP tools.
+
+These tests register the tools on a real :class:`fastmcp.FastMCP` instance and
+invoke them through the FastMCP tool API so the production code path is
+exercised (and recorded by coverage). All yfinance/network access is mocked via
+``monkeypatch.setattr("yfinance.Ticker", ...)`` so the suite is
+network-independent.
+
+The module-level helper functions operate on plain pandas objects and are unit
+tested directly against small, controlled DataFrames.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import ValidationError, YahooFinanceError
+from ib_sec_mcp.mcp.tools.technical_analysis import (
+    _analyze_timeframe_confluence,
+    _analyze_trends,
+    _analyze_volume,
+    _calculate_indicators,
+    _calculate_pivot_points,
+    _find_support_resistance,
+    _generate_signals,
+    register_technical_analysis_tools,
+)
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+PATCH_TARGET = "yfinance.Ticker"
+
+
+def _make_history(rows: int = 250, seed: int = 7) -> pd.DataFrame:
+    """Build a realistic OHLCV DataFrame with enough rows for all indicators.
+
+    A gently trending random walk keeps Close above the long-term SMA so trend
+    and signal logic produce deterministic, non-NaN output.
+    """
+    rng = np.random.default_rng(seed)
+    index = pd.date_range(end="2026-01-01", periods=rows, freq="D")
+
+    # Upward drift plus mild noise -> non-degenerate highs/lows/volume.
+    base = 100.0 + np.cumsum(rng.normal(0.15, 1.0, rows))
+    base = np.maximum(base, 5.0)
+    close = base
+    open_ = base + rng.normal(0.0, 0.3, rows)
+    high = np.maximum(open_, close) + np.abs(rng.normal(0.5, 0.3, rows))
+    low = np.minimum(open_, close) - np.abs(rng.normal(0.5, 0.3, rows))
+    volume = rng.integers(1_000_000, 5_000_000, rows)
+
+    return pd.DataFrame(
+        {
+            "Open": open_,
+            "High": high,
+            "Low": low,
+            "Close": close,
+            "Volume": volume,
+        },
+        index=index,
+    )
+
+
+class FakeTicker:
+    """yfinance ticker fake whose ``history`` returns a preset DataFrame.
+
+    ``history_result`` may be a DataFrame (returned for every period) or an
+    Exception instance (raised when ``history`` is called).
+    """
+
+    history_result: object = None
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def history(self, *args: object, **kwargs: object) -> pd.DataFrame:
+        result = type(self).history_result
+        if isinstance(result, Exception):
+            raise result
+        assert isinstance(result, pd.DataFrame)
+        return result
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with technical analysis tools registered."""
+    mcp = FastMCP("test")
+    register_technical_analysis_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[object], None]:
+    """Install FakeTicker with the given ``history`` payload for the test."""
+
+    def _apply(history_result: object) -> None:
+        monkeypatch.setattr(FakeTicker, "history_result", history_result)
+        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+
+    return _apply
+
+
+# ---------------------------------------------------------------------------
+# get_stock_analysis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_stock_analysis_happy_path(
+    test_mcp: FastMCP, patch_history: Callable[[object], None]
+) -> None:
+    """A successful analysis returns valid JSON with all top-level sections."""
+    patch_history(_make_history())
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_stock_analysis",
+        symbol="PG",
+        timeframe="1d",
+        lookback_days=252,
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["symbol"] == "PG"
+    assert data["timeframe"] == "1d"
+    assert isinstance(data["current_price"], float)
+    for key in (
+        "support_resistance",
+        "trend_analysis",
+        "technical_indicators",
+        "pivot_points",
+        "volume_analysis",
+        "trading_signals",
+    ):
+        assert key in data
+
+    indicators = data["technical_indicators"]
+    assert set(indicators) == {"rsi", "macd", "adx", "atr"}
+    signals = data["trading_signals"]
+    assert "recommendation" in signals
+    assert "confidence" in signals
+    assert isinstance(signals["signals"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_stock_analysis_empty_dataframe_raises(
+    test_mcp: FastMCP, patch_history: Callable[[object], None]
+) -> None:
+    """An empty history frame surfaces as a YahooFinanceError."""
+    patch_history(pd.DataFrame())
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_analysis",
+            symbol="PG",
+            timeframe="1d",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_analysis_yfinance_error_wrapped(
+    test_mcp: FastMCP, patch_history: Callable[[object], None]
+) -> None:
+    """An unexpected yfinance failure is wrapped in YahooFinanceError."""
+    patch_history(RuntimeError("network down"))
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_analysis",
+            symbol="PG",
+            timeframe="1d",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_analysis_invalid_symbol_raises(test_mcp: FastMCP) -> None:
+    """An invalid symbol is rejected by validation before any fetch."""
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_analysis",
+            symbol="!!bad!!",
+            timeframe="1d",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_stock_analysis_invalid_timeframe_raises(
+    test_mcp: FastMCP, patch_history: Callable[[object], None]
+) -> None:
+    """An unsupported timeframe is rejected with ValidationError."""
+    patch_history(_make_history())
+
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "get_stock_analysis",
+            symbol="PG",
+            timeframe="3h",
+            ctx=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_multi_timeframe_analysis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_multi_timeframe_analysis_happy_path(
+    test_mcp: FastMCP, patch_history: Callable[[object], None]
+) -> None:
+    """Multi-timeframe analysis returns each timeframe plus confluence."""
+    patch_history(_make_history())
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_multi_timeframe_analysis",
+        symbol="PG",
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["symbol"] == "PG"
+    assert set(data["timeframes"]) == {"daily", "weekly", "monthly"}
+    assert data["timeframes"]["daily"]["timeframe"] == "1d"
+    assert data["timeframes"]["weekly"]["timeframe"] == "1wk"
+    assert data["timeframes"]["monthly"]["timeframe"] == "1mo"
+
+    confluence = data["confluence_analysis"]
+    for key in (
+        "score",
+        "assessment",
+        "trends_aligned",
+        "indicators_aligned",
+        "divergences",
+        "recommendation",
+        "higher_timeframe_context",
+    ):
+        assert key in confluence
+
+
+@pytest.mark.asyncio
+async def test_get_multi_timeframe_analysis_propagates_error(
+    test_mcp: FastMCP, patch_history: Callable[[object], None]
+) -> None:
+    """An empty frame in any timeframe surfaces as YahooFinanceError."""
+    patch_history(pd.DataFrame())
+
+    with pytest.raises(YahooFinanceError):
+        await call_tool_fn(
+            test_mcp,
+            "get_multi_timeframe_analysis",
+            symbol="PG",
+            ctx=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_multi_timeframe_analysis_invalid_symbol_raises(test_mcp: FastMCP) -> None:
+    """An invalid symbol is rejected before any fetch."""
+    with pytest.raises(ValidationError):
+        await call_tool_fn(
+            test_mcp,
+            "get_multi_timeframe_analysis",
+            symbol="!!bad!!",
+            ctx=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_indicators_keys_and_signals() -> None:
+    """Indicators dict has the expected nested structure and RSI signal logic."""
+    hist = _make_history()
+    indicators = _calculate_indicators(hist)
+
+    assert set(indicators) == {"rsi", "macd", "adx", "atr"}
+    assert set(indicators["rsi"]) == {"value", "signal"}
+    assert indicators["rsi"]["signal"] in {"overbought", "oversold", "neutral"}
+    assert set(indicators["macd"]) == {"value", "signal", "histogram", "trend"}
+    assert indicators["macd"]["trend"] in {"bullish", "bearish"}
+    assert indicators["adx"]["trend_strength"] in {"strong", "weak", "insufficient_data"}
+    assert indicators["atr"]["volatility"] in {"high", "low", "normal"}
+
+
+def test_calculate_indicators_rsi_overbought() -> None:
+    """A monotonically rising series drives RSI to the overbought band."""
+    index = pd.date_range(end="2026-01-01", periods=60, freq="D")
+    close = pd.Series(np.linspace(100.0, 160.0, 60), index=index)
+    hist = pd.DataFrame(
+        {
+            "Open": close,
+            "High": close + 1.0,
+            "Low": close - 1.0,
+            "Close": close,
+            "Volume": np.full(60, 1_000_000),
+        },
+        index=index,
+    )
+
+    indicators = _calculate_indicators(hist)
+
+    assert indicators["rsi"]["value"] is not None
+    assert indicators["rsi"]["value"] > 70
+    assert indicators["rsi"]["signal"] == "overbought"
+
+
+def test_find_support_resistance_structure() -> None:
+    """Support/resistance returns lists and a categorical current level."""
+    hist = _make_history()
+    sr = _find_support_resistance(hist)
+
+    assert set(sr) == {
+        "resistance_levels",
+        "support_levels",
+        "nearest_resistance",
+        "nearest_support",
+        "current_level",
+    }
+    assert isinstance(sr["resistance_levels"], list)
+    assert isinstance(sr["support_levels"], list)
+    assert sr["current_level"] in {"near_resistance", "near_support", "neutral"}
+    # Resistance levels (when present) sit above current price; support below.
+    current = float(hist["Close"].iloc[-1])
+    for level in sr["resistance_levels"]:
+        assert level > current
+    for level in sr["support_levels"]:
+        assert level < current
+
+
+def test_analyze_trends_uptrend_alignment() -> None:
+    """A strictly rising series yields aligned uptrends and strong strength."""
+    index = pd.date_range(end="2026-01-01", periods=250, freq="D")
+    close = pd.Series(np.linspace(50.0, 300.0, 250), index=index)
+
+    trends = _analyze_trends(close)
+
+    assert set(trends) == {
+        "short_term",
+        "medium_term",
+        "long_term",
+        "trend_strength",
+        "sma_20",
+        "sma_50",
+        "sma_200",
+    }
+    assert trends["short_term"] == "uptrend"
+    assert trends["medium_term"] == "uptrend"
+    assert trends["long_term"] == "uptrend"
+    assert trends["trend_strength"] == "strong"
+
+
+def test_analyze_trends_insufficient_long_term() -> None:
+    """Fewer than 200 points leaves the long-term trend undetermined."""
+    index = pd.date_range(end="2026-01-01", periods=60, freq="D")
+    close = pd.Series(np.linspace(50.0, 120.0, 60), index=index)
+
+    trends = _analyze_trends(close)
+
+    assert trends["long_term"] == "insufficient_data"
+    assert trends["sma_200"] is None
+
+
+def test_calculate_pivot_points_classic_relationships() -> None:
+    """Classic pivot points satisfy the standard ordering r2 > r1 > s1 > s2."""
+    index = pd.date_range(end="2026-01-01", periods=5, freq="D")
+    hist = pd.DataFrame(
+        {
+            "Open": [10, 11, 12, 13, 14],
+            "High": [12, 13, 14, 15, 16],
+            "Low": [8, 9, 10, 11, 12],
+            "Close": [11, 12, 13, 14, 15],
+            "Volume": [100, 100, 100, 100, 100],
+        },
+        index=index,
+    )
+
+    pivots = _calculate_pivot_points(hist)
+
+    # Uses the second-to-last row: high=15, low=11, close=14 -> pivot=40/3.
+    classic = pivots["classic"]
+    assert classic["pivot"] == round((15 + 11 + 14) / 3, 2)
+    assert classic["resistance_2"] > classic["resistance_1"] > classic["pivot"]
+    assert classic["pivot"] > classic["support_1"] > classic["support_2"]
+    assert set(pivots) == {"classic", "fibonacci"}
+
+
+def test_analyze_volume_structure_and_obv() -> None:
+    """Volume analysis returns ratio/trend fields and a directional OBV trend."""
+    index = pd.date_range(end="2026-01-01", periods=30, freq="D")
+    close = pd.Series(np.linspace(100.0, 130.0, 30), index=index)
+    hist = pd.DataFrame(
+        {
+            "Open": close,
+            "High": close + 1.0,
+            "Low": close - 1.0,
+            "Close": close,
+            "Volume": np.full(30, 1_000_000),
+        },
+        index=index,
+    )
+
+    vol = _analyze_volume(hist)
+
+    assert set(vol) == {
+        "current_volume",
+        "average_volume_20d",
+        "volume_ratio",
+        "volume_trend",
+        "obv_trend",
+    }
+    assert vol["current_volume"] == 1_000_000
+    assert vol["volume_trend"] in {"high", "low", "normal"}
+    # Strictly rising closes accumulate positive OBV -> bullish.
+    assert vol["obv_trend"] == "bullish"
+
+
+def test_generate_signals_bullish_recommendation() -> None:
+    """A confluence of bullish inputs yields a buy-side recommendation."""
+    support_resistance = {
+        "current_level": "near_support",
+        "nearest_support": 95.0,
+        "nearest_resistance": 110.0,
+    }
+    trend_analysis = {"trend_strength": "strong", "short_term": "uptrend"}
+    indicators = {
+        "rsi": {"value": 25.0, "signal": "oversold"},
+        "macd": {"trend": "bullish", "histogram": 0.5},
+        "adx": {"value": 30.0, "trend_strength": "strong"},
+    }
+    volume_analysis = {"volume_trend": "high", "obv_trend": "bullish"}
+
+    signals = _generate_signals(
+        100.0, support_resistance, trend_analysis, indicators, volume_analysis
+    )
+
+    assert set(signals) == {
+        "recommendation",
+        "confidence",
+        "score",
+        "signals",
+        "entry_zone",
+        "stop_loss",
+        "take_profit",
+        "risk_reward_ratio",
+    }
+    assert signals["score"] > 0.5
+    assert signals["recommendation"] == "strong_buy"
+    # Bullish branch builds an entry zone around nearest support.
+    assert signals["entry_zone"] is not None
+    assert signals["stop_loss"] is not None
+    assert signals["risk_reward_ratio"] is not None
+
+
+def test_generate_signals_bearish_recommendation() -> None:
+    """A confluence of bearish inputs yields a sell recommendation."""
+    support_resistance = {
+        "current_level": "near_resistance",
+        "nearest_support": 90.0,
+        "nearest_resistance": 105.0,
+    }
+    trend_analysis = {"trend_strength": "strong", "short_term": "downtrend"}
+    indicators = {
+        "rsi": {"value": 80.0, "signal": "overbought"},
+        "macd": {"trend": "bearish", "histogram": -0.5},
+        "adx": {"value": 30.0, "trend_strength": "strong"},
+    }
+    volume_analysis = {"volume_trend": "high", "obv_trend": "bearish"}
+
+    signals = _generate_signals(
+        100.0, support_resistance, trend_analysis, indicators, volume_analysis
+    )
+
+    assert signals["score"] < -0.5
+    assert signals["recommendation"] == "sell"
+
+
+def test_generate_signals_neutral_hold() -> None:
+    """Balanced inputs leave the recommendation at hold with no entry zone."""
+    support_resistance = {
+        "current_level": "neutral",
+        "nearest_support": None,
+        "nearest_resistance": None,
+    }
+    trend_analysis = {"trend_strength": "weak", "short_term": "uptrend"}
+    indicators = {
+        "rsi": {"value": 50.0, "signal": "neutral"},
+        "macd": {"trend": "bullish", "histogram": 0.0},
+        "adx": {"value": 10.0, "trend_strength": "weak"},
+    }
+    volume_analysis = {"volume_trend": "normal", "obv_trend": "neutral"}
+
+    signals = _generate_signals(
+        100.0, support_resistance, trend_analysis, indicators, volume_analysis
+    )
+
+    assert signals["recommendation"] == "hold"
+    assert signals["entry_zone"] is None
+    assert signals["risk_reward_ratio"] is None
+
+
+def test_analyze_timeframe_confluence_strong() -> None:
+    """All timeframes aligned produces strong confluence with no divergences."""
+    daily = {
+        "trend_analysis": {"short_term": "uptrend"},
+        "technical_indicators": {"rsi": {"signal": "neutral"}},
+    }
+    weekly = {
+        "trend_analysis": {"medium_term": "uptrend"},
+        "technical_indicators": {"rsi": {"signal": "neutral"}},
+        "support_resistance": {"nearest_support": 90.0, "nearest_resistance": 110.0},
+    }
+    monthly = {"trend_analysis": {"long_term": "uptrend"}}
+
+    confluence = _analyze_timeframe_confluence(daily, weekly, monthly)
+
+    assert confluence["trends_aligned"] is True
+    assert confluence["indicators_aligned"] is True
+    assert confluence["score"] == pytest.approx(0.8)
+    assert confluence["assessment"] == "strong_confluence"
+    assert confluence["divergences"] == []
+    assert confluence["higher_timeframe_context"]["weekly_support"] == 90.0
+
+
+def test_analyze_timeframe_confluence_divergent() -> None:
+    """Conflicting trends produce low confluence and recorded divergences."""
+    daily = {
+        "trend_analysis": {"short_term": "uptrend"},
+        "technical_indicators": {"rsi": {"signal": "overbought"}},
+    }
+    weekly = {
+        "trend_analysis": {"medium_term": "downtrend"},
+        "technical_indicators": {"rsi": {"signal": "neutral"}},
+        "support_resistance": {"nearest_support": None, "nearest_resistance": None},
+    }
+    monthly = {"trend_analysis": {"long_term": "uptrend"}}
+
+    confluence = _analyze_timeframe_confluence(daily, weekly, monthly)
+
+    assert confluence["trends_aligned"] is False
+    assert confluence["indicators_aligned"] is False
+    assert confluence["score"] == pytest.approx(0.0)
+    assert confluence["assessment"] == "low_confluence"
+    assert len(confluence["divergences"]) == 2


### PR DESCRIPTION
## Summary

Resolves #123 (Wave 3, `test` / `parallel-safe`).

Adds network-independent unit tests for six previously-untested market-data MCP tool modules. Coverage for these modules was effectively **0%** (only server smoke-registration was exercised). All `yfinance`/network access is mocked, so the suite stays deterministic and offline.

## Changes (6 new test files, 88 tests)

| File | Tests | Module coverage after |
| --- | --- | --- |
| `tests/mcp/test_stock_data.py` | 15 | `stock_data.py` 87% |
| `tests/mcp/test_stock_news.py` | 12 | `stock_news.py` 85% |
| `tests/mcp/test_options.py` | 19 | `options.py` 80% |
| `tests/mcp/test_technical_analysis.py` | 20 | `technical_analysis.py` 91% |
| `tests/mcp/test_market_comparison.py` | 11 | `market_comparison.py` 91% |
| `tests/mcp/test_etf_comparison.py` | 11 | `etf_comparison.py` 80% |

## Approach

- Each file registers the tool on a real `FastMCP` instance and invokes it through `call_tool_fn` (`tests/mcp/_fastmcp_helpers.py`) so the production path is exercised and recorded by coverage — matching the existing `test_earnings_calendar.py` style.
- Mocking patches the real `yfinance.Ticker` attribute (the modules `import yfinance as yf` lazily inside each tool), per `.claude/rules/testing.md`. `FakeTicker` returns pandas-backed `history()` DataFrames, `.info` dicts, `.news`, and option chains with the exact columns each tool reads.
- Coverage spans happy paths, input-validation errors, empty-data handling, and external-API-failure → graceful degradation (assert each tool's **actual** behavior — some raise `ValidationError`/`YahooFinanceError`, others return `{"error": ...}` JSON).
- `technical_analysis` also unit-tests the module-level helpers (`_calculate_indicators`, `_find_support_resistance`, `_analyze_trends`, `_calculate_pivot_points`, `_analyze_volume`, `_generate_signals`, `_analyze_timeframe_confluence`) directly.

## Scope

No source files changed — only the six new test files declared in the issue's `Owns` list. File-isolated, parallel-safe.

## Testing

- `uv run pytest` → **1070 passed**, global coverage gate (48%) reached at **69.43%**.
- `uv run ruff check` + `ruff format --check` on all 6 files → clean.

## Follow-up note (not addressed here)

In `etf_comparison.py`, a price series with zero down days makes `downside_std` NaN; the guard `if downside_std != 0` passes (`NaN != 0`), so `sortino_ratio` serializes as a bare `NaN` token in JSON. Tests avoid this with realistic series; stricter NaN handling could be a separate hardening issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)