### PR TITLE
test(mcp): add tests for portfolio/position/sentiment tools + middleware & resources

### DIFF
--- a/tests/analyzers/sentiment/test_technical.py
+++ b/tests/analyzers/sentiment/test_technical.py
@@ -15,22 +15,21 @@ from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
 from ib_sec_mcp.analyzers.sentiment.technical import TechnicalSentimentAnalyzer
 
 
-class FakeTicker:
-    """Minimal yfinance.Ticker stand-in returning a fixed history DataFrame."""
-
-    df: pd.DataFrame = pd.DataFrame()
-
-    def __init__(self, symbol: str) -> None:
-        self.symbol = symbol
-
-    def history(self, *args: object, **kwargs: object) -> pd.DataFrame:
-        return self.df
-
-
 @pytest.fixture()
 def patch_ticker(monkeypatch: pytest.MonkeyPatch):
     def _apply(df: pd.DataFrame) -> None:
-        monkeypatch.setattr(FakeTicker, "df", df)
+        # Define the fake ticker inside the closure so the history DataFrame is
+        # captured per-call rather than stored on a shared class attribute. This
+        # keeps tests isolated even under parallel execution (e.g. pytest-xdist).
+        class FakeTicker:
+            """Minimal yfinance.Ticker stand-in returning a fixed history DataFrame."""
+
+            def __init__(self, symbol: str) -> None:
+                self.symbol = symbol
+
+            def history(self, *args: object, **kwargs: object) -> pd.DataFrame:
+                return df
+
         monkeypatch.setattr("ib_sec_mcp.analyzers.sentiment.technical.yf.Ticker", FakeTicker)
 
     return _apply

--- a/tests/analyzers/sentiment/test_technical.py
+++ b/tests/analyzers/sentiment/test_technical.py
@@ -1,0 +1,106 @@
+"""Tests for ``TechnicalSentimentAnalyzer``.
+
+The RSI/MACD helpers are pure and tested directly on constructed price series.
+``analyze_sentiment`` fetches data via yfinance, which is patched with a fake
+ticker returning deterministic DataFrames to exercise the trend branches and the
+graceful-degradation paths (insufficient / empty data -> neutral score).
+"""
+
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
+from ib_sec_mcp.analyzers.sentiment.technical import TechnicalSentimentAnalyzer
+
+
+class FakeTicker:
+    """Minimal yfinance.Ticker stand-in returning a fixed history DataFrame."""
+
+    df: pd.DataFrame = pd.DataFrame()
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def history(self, *args: object, **kwargs: object) -> pd.DataFrame:
+        return self.df
+
+
+@pytest.fixture()
+def patch_ticker(monkeypatch: pytest.MonkeyPatch):
+    def _apply(df: pd.DataFrame) -> None:
+        monkeypatch.setattr(FakeTicker, "df", df)
+        monkeypatch.setattr("ib_sec_mcp.analyzers.sentiment.technical.yf.Ticker", FakeTicker)
+
+    return _apply
+
+
+def close_df(values: list[float]) -> pd.DataFrame:
+    return pd.DataFrame({"Close": values})
+
+
+class TestRsiMacdHelpers:
+    def test_rsi_high_for_rising_prices(self) -> None:
+        analyzer = TechnicalSentimentAnalyzer()
+        prices = pd.Series([float(p) for p in range(1, 60)])  # strictly increasing
+        rsi = analyzer.calculate_rsi(prices)
+        assert rsi == pytest.approx(100.0)
+
+    def test_rsi_low_for_falling_prices(self) -> None:
+        analyzer = TechnicalSentimentAnalyzer()
+        prices = pd.Series([float(p) for p in range(60, 1, -1)])  # strictly decreasing
+        rsi = analyzer.calculate_rsi(prices)
+        assert rsi == pytest.approx(0.0)
+
+    def test_macd_returns_two_floats(self) -> None:
+        analyzer = TechnicalSentimentAnalyzer()
+        prices = pd.Series([float(p) for p in range(1, 60)])
+        macd, signal = analyzer.calculate_macd(prices)
+        assert isinstance(macd, float)
+        assert isinstance(signal, float)
+
+
+class TestAnalyzeSentiment:
+    async def test_uptrend_flags_strong_uptrend(self, patch_ticker) -> None:
+        patch_ticker(close_df([100.0 + i for i in range(60)]))
+        analyzer = TechnicalSentimentAnalyzer()
+        result = await analyzer.analyze_sentiment("AAPL")
+
+        assert isinstance(result, SentimentScore)
+        assert "strong_uptrend" in result.key_themes
+        assert Decimal("-1.0") <= result.score <= Decimal("1.0")
+        assert result.confidence == Decimal("1.0")  # 3 indicators computed
+
+    async def test_downtrend_flags_strong_downtrend(self, patch_ticker) -> None:
+        patch_ticker(close_df([200.0 - i for i in range(60)]))
+        analyzer = TechnicalSentimentAnalyzer()
+        result = await analyzer.analyze_sentiment("AAPL")
+
+        assert "strong_downtrend" in result.risk_factors
+        assert result.score < Decimal("0")
+
+    async def test_insufficient_data_returns_neutral(self, patch_ticker) -> None:
+        patch_ticker(close_df([100.0 + i for i in range(10)]))  # < 50 rows
+        analyzer = TechnicalSentimentAnalyzer()
+        result = await analyzer.analyze_sentiment("AAPL")
+
+        assert result.score == Decimal("0.0")
+        assert result.confidence == Decimal("0.0")
+        assert "technical_analysis_error" in result.risk_factors
+
+    async def test_empty_history_returns_neutral(self, patch_ticker) -> None:
+        patch_ticker(pd.DataFrame({"Close": []}))
+        analyzer = TechnicalSentimentAnalyzer()
+        result = await analyzer.analyze_sentiment("AAPL")
+
+        assert result.score == Decimal("0.0")
+        assert result.confidence == Decimal("0.0")
+
+    async def test_score_and_confidence_are_decimal(self, patch_ticker) -> None:
+        patch_ticker(close_df([100.0 + (i % 5) for i in range(60)]))
+        analyzer = TechnicalSentimentAnalyzer()
+        result = await analyzer.analyze_sentiment("AAPL")
+
+        assert isinstance(result.score, Decimal)
+        assert isinstance(result.confidence, Decimal)

--- a/tests/mcp/test_etf_calculator_tools.py
+++ b/tests/mcp/test_etf_calculator_tools.py
@@ -1,0 +1,131 @@
+"""Tests for the ETF calculator MCP tools.
+
+Covers ``calculate_etf_swap`` and ``calculate_portfolio_swap`` wrappers, including
+trading-fee resolution (param vs TRADING_FEE_USD env var) and payback serialization.
+"""
+
+import json
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.tools.etf_calculator_tools import register_etf_calculator_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+SINGLE_SWAP_KWARGS = {
+    "from_symbol": "TLT",
+    "from_shares": 200,
+    "from_price": 91.34,
+    "from_expense_ratio": 0.0015,
+    "from_dividend_yield": 0.0433,
+    "from_withholding_tax": 0.30,
+    "to_symbol": "IDTL",
+    "to_price": 3.40,
+    "to_expense_ratio": 0.0007,
+    "to_dividend_yield": 0.0445,
+    "to_withholding_tax": 0.15,
+}
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    register_etf_calculator_tools(mcp)
+    return mcp
+
+
+class TestCalculateEtfSwap:
+    async def test_returns_valid_json_with_expected_keys(self, test_mcp: FastMCP) -> None:
+        result = await call_tool_fn(test_mcp, "calculate_etf_swap", **SINGLE_SWAP_KWARGS)
+        data = json.loads(result)
+
+        assert data["required_shares"] == 5373
+        assert data["from_etf"]["symbol"] == "TLT"
+        assert data["to_etf"]["symbol"] == "IDTL"
+        assert "purchase_amount" in data
+        assert "annual_net_benefit" in data
+        assert "formatted_output" in data
+
+    async def test_positive_benefit_payback_is_number(self, test_mcp: FastMCP) -> None:
+        result = await call_tool_fn(test_mcp, "calculate_etf_swap", **SINGLE_SWAP_KWARGS)
+        data = json.loads(result)
+        assert isinstance(data["payback_period_months"], (int, float))
+        assert data["payback_period_months"] > 0
+
+    async def test_no_benefit_payback_serialized_as_null(self, test_mcp: FastMCP) -> None:
+        kwargs = {
+            "from_symbol": "GOOD",
+            "from_shares": 100,
+            "from_price": 100.0,
+            "from_expense_ratio": 0.0003,
+            "from_dividend_yield": 0.02,
+            "from_withholding_tax": 0.00,
+            "to_symbol": "BAD",
+            "to_price": 100.0,
+            "to_expense_ratio": 0.0015,
+            "to_dividend_yield": 0.02,
+            "to_withholding_tax": 0.30,
+        }
+        result = await call_tool_fn(test_mcp, "calculate_etf_swap", **kwargs)
+        data = json.loads(result)
+        # Infinite payback is converted to None (JSON null), never "inf".
+        assert data["payback_period_months"] is None
+
+    async def test_trading_fee_from_env_var(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRADING_FEE_USD", "10")
+        cheap = json.loads(await call_tool_fn(test_mcp, "calculate_etf_swap", **SINGLE_SWAP_KWARGS))
+
+        monkeypatch.setenv("TRADING_FEE_USD", "150")
+        pricey = json.loads(
+            await call_tool_fn(test_mcp, "calculate_etf_swap", **SINGLE_SWAP_KWARGS)
+        )
+
+        assert pricey["payback_period_months"] > cheap["payback_period_months"]
+
+    async def test_explicit_trading_fee_overrides_env(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRADING_FEE_USD", "999")
+        result = await call_tool_fn(
+            test_mcp, "calculate_etf_swap", trading_fee_usd=10.0, **SINGLE_SWAP_KWARGS
+        )
+        explicit = json.loads(result)["payback_period_months"]
+
+        result_env = await call_tool_fn(test_mcp, "calculate_etf_swap", **SINGLE_SWAP_KWARGS)
+        env_based = json.loads(result_env)["payback_period_months"]
+        # Explicit $10 fee gives a much shorter payback than the $999 env fee.
+        assert explicit < env_based
+
+
+class TestCalculatePortfolioSwap:
+    async def test_portfolio_swap_returns_summary(self, test_mcp: FastMCP) -> None:
+        swaps = json.dumps(
+            [
+                {
+                    "from_symbol": "VOO",
+                    "from_shares": 40,
+                    "from_price": 607.39,
+                    "from_expense_ratio": 0.0003,
+                    "from_dividend_yield": 0.0115,
+                    "from_withholding_tax": 0.30,
+                    "to_symbol": "CSPX",
+                    "to_price": 714.78,
+                    "to_expense_ratio": 0.0007,
+                    "to_dividend_yield": 0.0115,
+                    "to_withholding_tax": 0.00,
+                }
+            ]
+        )
+        result = await call_tool_fn(test_mcp, "calculate_portfolio_swap", swaps=swaps)
+        data = json.loads(result)
+
+        assert len(data["individual_results"]) == 1
+        assert data["summary"]["total_from_shares"] == 40
+        assert "annual_net_benefit" in data["summary"]
+        assert data["individual_results"][0]["from_etf"]["symbol"] == "VOO"
+
+    async def test_malformed_swaps_json_raises(self, test_mcp: FastMCP) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            await call_tool_fn(test_mcp, "calculate_portfolio_swap", swaps="not json")

--- a/tests/mcp/test_middleware.py
+++ b/tests/mcp/test_middleware.py
@@ -1,0 +1,183 @@
+"""Tests for IB Analytics MCP middleware.
+
+Covers the error-tracking, retry, and logging middleware. A key acceptance
+criterion (Issue #124) is that the middleware does not leak sensitive request
+payloads into logs/error responses, which is verified explicitly below.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from ib_sec_mcp.mcp.middleware import (
+    IBAnalyticsErrorMiddleware,
+    IBAnalyticsLoggingMiddleware,
+    IBAnalyticsRetryMiddleware,
+)
+
+MIDDLEWARE_LOGGER = "ib_sec_mcp.mcp.middleware"
+
+
+def make_context(method: str = "tools/call", **extra: object) -> SimpleNamespace:
+    """Build a minimal MiddlewareContext-like object."""
+    return SimpleNamespace(method=method, source="client", **extra)
+
+
+def ok_call_next(value: object = "result"):
+    async def _call_next(context: object) -> object:
+        return value
+
+    return _call_next
+
+
+def raising_call_next(exc: Exception):
+    async def _call_next(context: object) -> object:
+        raise exc
+
+    return _call_next
+
+
+class TestErrorMiddleware:
+    async def test_success_passes_through(self) -> None:
+        mw = IBAnalyticsErrorMiddleware()
+        result = await mw.on_message(make_context(), ok_call_next("ok"))
+        assert result == "ok"
+        assert mw.get_error_stats() == {}
+
+    async def test_exception_is_tracked_and_reraised(self) -> None:
+        mw = IBAnalyticsErrorMiddleware()
+        err = ValueError("boom")
+        with pytest.raises(ValueError):
+            await mw.on_message(make_context(method="tools/call"), raising_call_next(err))
+
+        stats = mw.get_error_stats()
+        assert stats["ValueError:tools/call"] == 1
+
+    async def test_repeated_errors_increment_count(self) -> None:
+        mw = IBAnalyticsErrorMiddleware()
+        for _ in range(3):
+            with pytest.raises(KeyError):
+                await mw.on_message(make_context(), raising_call_next(KeyError("k")))
+        assert mw.get_error_stats()["KeyError:tools/call"] == 3
+
+    async def test_get_error_stats_returns_copy(self) -> None:
+        mw = IBAnalyticsErrorMiddleware()
+        with pytest.raises(ValueError):
+            await mw.on_message(make_context(), raising_call_next(ValueError("x")))
+        stats = mw.get_error_stats()
+        stats["mutated"] = 999
+        assert "mutated" not in mw.get_error_stats()
+
+
+class TestRetryMiddleware:
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch: pytest.MonkeyPatch):
+        """Record (and skip) backoff sleeps so tests run instantly."""
+        self.delays: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            self.delays.append(delay)
+
+        monkeypatch.setattr("ib_sec_mcp.mcp.middleware.asyncio.sleep", fake_sleep)
+
+    async def test_retries_then_succeeds(self) -> None:
+        mw = IBAnalyticsRetryMiddleware(max_retries=3, retry_delay=1.0)
+        calls = {"n": 0}
+
+        async def flaky(context: object) -> str:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ConnectionError("transient")
+            return "recovered"
+
+        result = await mw.on_message(make_context(), flaky)
+        assert result == "recovered"
+        assert calls["n"] == 3
+
+    async def test_exhausts_retries_and_raises_last(self) -> None:
+        mw = IBAnalyticsRetryMiddleware(max_retries=2, retry_delay=1.0)
+        calls = {"n": 0}
+
+        async def always_fail(context: object) -> str:
+            calls["n"] += 1
+            raise TimeoutError("nope")
+
+        with pytest.raises(TimeoutError):
+            await mw.on_message(make_context(), always_fail)
+        # Initial attempt + 2 retries = 3 calls.
+        assert calls["n"] == 3
+
+    async def test_exponential_backoff_delays(self) -> None:
+        mw = IBAnalyticsRetryMiddleware(max_retries=3, retry_delay=1.0)
+
+        async def always_fail(context: object) -> str:
+            raise ConnectionError("transient")
+
+        with pytest.raises(ConnectionError):
+            await mw.on_message(make_context(), always_fail)
+        # delay * 2**attempt for attempts 0,1,2 => 1, 2, 4
+        assert self.delays == [1.0, 2.0, 4.0]
+
+    async def test_non_retryable_exception_raised_immediately(self) -> None:
+        mw = IBAnalyticsRetryMiddleware(max_retries=3, retry_delay=1.0)
+        calls = {"n": 0}
+
+        async def value_error(context: object) -> str:
+            calls["n"] += 1
+            raise ValueError("not retryable")
+
+        with pytest.raises(ValueError):
+            await mw.on_message(make_context(), value_error)
+        assert calls["n"] == 1
+        assert self.delays == []
+
+
+class TestLoggingMiddleware:
+    async def test_logs_request_and_response(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger=MIDDLEWARE_LOGGER)
+        mw = IBAnalyticsLoggingMiddleware(log_level=logging.DEBUG)
+        result = await mw.on_message(make_context(method="resources/read"), ok_call_next("data"))
+
+        assert result == "data"
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("→ resources/read" in m for m in messages)
+        assert any("← resources/read" in m for m in messages)
+
+    async def test_error_is_logged_and_reraised(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger=MIDDLEWARE_LOGGER)
+        mw = IBAnalyticsLoggingMiddleware(log_level=logging.DEBUG)
+        with pytest.raises(RuntimeError):
+            await mw.on_message(make_context(), raising_call_next(RuntimeError("fail")))
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_records, "expected an ERROR-level log on failure"
+
+    async def test_request_payload_is_not_leaked_to_logs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Sensitive data attached to the context must never appear in log output."""
+        caplog.set_level(logging.DEBUG, logger=MIDDLEWARE_LOGGER)
+        secret = "TOKEN_abcdef123456_SECRET"
+        context = make_context(method="tools/call", message={"token": secret})
+
+        mw = IBAnalyticsLoggingMiddleware(log_level=logging.DEBUG)
+        await mw.on_message(context, ok_call_next("ok"))
+
+        combined = "\n".join(r.getMessage() for r in caplog.records)
+        assert secret not in combined
+
+    async def test_error_message_payload_not_leaked_by_logging_middleware(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """On error, the logging middleware records only method + error type, not payload."""
+        caplog.set_level(logging.DEBUG, logger=MIDDLEWARE_LOGGER)
+        secret = "PASSWORD_supersecret"
+        context = make_context(method="tools/call", message={"password": secret})
+
+        mw = IBAnalyticsLoggingMiddleware(log_level=logging.DEBUG)
+        with pytest.raises(RuntimeError):
+            await mw.on_message(context, raising_call_next(RuntimeError("internal")))
+
+        combined = "\n".join(r.getMessage() for r in caplog.records)
+        assert secret not in combined

--- a/tests/mcp/test_portfolio_analytics.py
+++ b/tests/mcp/test_portfolio_analytics.py
@@ -1,0 +1,219 @@
+"""Tests for the portfolio analytics MCP tools.
+
+``calculate_portfolio_metrics`` and ``analyze_portfolio_correlation`` both fetch
+price history from yfinance, which is patched with a fake ticker returning a
+varied deterministic series. Validation/early-exit branches are tested without
+any network access.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import FileOperationError, ValidationError
+from ib_sec_mcp.mcp.tools.portfolio_analytics import register_portfolio_analytics_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+# Multi-position XML (filename carries the date range parsed by the tool).
+XML_TWO_POSITIONS = """<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="test" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20250131">
+      <AccountInformation accountId="U1234567" acctAlias="Test Account" />
+      <CashReport>
+        <CashReportCurrency currency="BASE_SUMMARY"
+          startingCash="10000" endingCash="10000" endingSettledCash="10000" />
+      </CashReport>
+      <OpenPositions>
+        <OpenPosition symbol="CSPX" description="ISHARES CORE S&amp;P 500"
+          assetCategory="STK" currency="USD" fxRateToBase="1"
+          isin="IE00B5BMR087" position="10" markPrice="735.00"
+          positionValue="7350" costBasisMoney="6000" fifoPnlUnrealized="1350"
+          reportDate="20250131" multiplier="1" />
+        <OpenPosition symbol="IDTL" description="ISHARES USD TRES 20PLUS YR"
+          assetCategory="STK" currency="USD" fxRateToBase="1"
+          isin="IE00BSKRJZ44" position="100" markPrice="50.00"
+          positionValue="5000" costBasisMoney="4800" fifoPnlUnrealized="200"
+          reportDate="20250131" multiplier="1" />
+      </OpenPositions>
+      <Trades />
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>"""
+
+XML_ONE_POSITION = """<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="test" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20250131">
+      <AccountInformation accountId="U1234567" acctAlias="Test Account" />
+      <CashReport>
+        <CashReportCurrency currency="BASE_SUMMARY"
+          startingCash="10000" endingCash="10000" endingSettledCash="10000" />
+      </CashReport>
+      <OpenPositions>
+        <OpenPosition symbol="CSPX" description="ISHARES CORE S&amp;P 500"
+          assetCategory="STK" currency="USD" fxRateToBase="1"
+          isin="IE00B5BMR087" position="10" markPrice="735.00"
+          positionValue="7350" costBasisMoney="6000" fifoPnlUnrealized="1350"
+          reportDate="20250131" multiplier="1" />
+      </OpenPositions>
+      <Trades />
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>"""
+
+XML_NO_POSITIONS = """<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="test" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20250131">
+      <AccountInformation accountId="U1234567" acctAlias="Test Account" />
+      <CashReport>
+        <CashReportCurrency currency="BASE_SUMMARY"
+          startingCash="10000" endingCash="10000" endingSettledCash="10000" />
+      </CashReport>
+      <OpenPositions />
+      <Trades />
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>"""
+
+
+def _varied_prices(n: int = 90) -> list[float]:
+    """Deterministic price series with both up and down moves (non-zero variance)."""
+    prices = []
+    value = 100.0
+    for i in range(n):
+        value += 1.5 if i % 3 else -1.0
+        prices.append(value)
+    return prices
+
+
+class FakeTicker:
+    """yfinance.Ticker stand-in returning a fixed varied Close history."""
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    def history(self, *args: object, **kwargs: object) -> pd.DataFrame:
+        return pd.DataFrame({"Close": _varied_prices()})
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    register_portfolio_analytics_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_yfinance(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("yfinance.Ticker", FakeTicker)
+
+
+def write_xml(
+    tmp_path: Path, content: str, name: str = "U1234567_2025-01-01_2025-01-31.xml"
+) -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    return str(path)
+
+
+class TestCalculatePortfolioMetricsValidation:
+    async def test_missing_file_raises_validation_error(self, test_mcp: FastMCP) -> None:
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "calculate_portfolio_metrics",
+                file_path="/nonexistent/portfolio.xml",
+                ctx=None,
+            )
+
+    async def test_invalid_period_raises(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        path = write_xml(tmp_path, XML_TWO_POSITIONS)
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "calculate_portfolio_metrics",
+                file_path=path,
+                period="bogus",
+                ctx=None,
+            )
+
+    async def test_invalid_risk_free_rate_raises(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        path = write_xml(tmp_path, XML_TWO_POSITIONS)
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "calculate_portfolio_metrics",
+                file_path=path,
+                risk_free_rate=5.0,  # 500% -> out of [0, 0.5]
+                ctx=None,
+            )
+
+    async def test_non_xml_content_raises_file_operation_error(
+        self, test_mcp: FastMCP, tmp_path: Path
+    ) -> None:
+        path = write_xml(tmp_path, "this is not xml at all")
+        with pytest.raises(FileOperationError):
+            await call_tool_fn(test_mcp, "calculate_portfolio_metrics", file_path=path, ctx=None)
+
+    async def test_no_positions_raises(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        path = write_xml(tmp_path, XML_NO_POSITIONS)
+        with pytest.raises(ValidationError):
+            await call_tool_fn(test_mcp, "calculate_portfolio_metrics", file_path=path, ctx=None)
+
+
+class TestCalculatePortfolioMetricsHappyPath:
+    async def test_returns_metrics_json(
+        self, test_mcp: FastMCP, tmp_path: Path, patch_yfinance
+    ) -> None:
+        path = write_xml(tmp_path, XML_TWO_POSITIONS)
+        result = await call_tool_fn(
+            test_mcp, "calculate_portfolio_metrics", file_path=path, ctx=None
+        )
+        data = json.loads(result)
+
+        assert data["portfolio_summary"]["num_positions"] == 2
+        assert "sharpe_ratio" in data["risk_adjusted_metrics"]
+        assert "maximum_drawdown_pct" in data["risk_metrics"]
+        assert "beta" in data["risk_metrics"]
+        assert set(data["interpretation"]) == {"sharpe", "sortino", "max_drawdown"}
+
+
+class TestAnalyzePortfolioCorrelation:
+    async def test_single_position_returns_message(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        path = write_xml(tmp_path, XML_ONE_POSITION)
+        result = await call_tool_fn(
+            test_mcp, "analyze_portfolio_correlation", file_path=path, ctx=None
+        )
+        data = json.loads(result)
+        assert data["num_positions"] == 1
+        assert "message" in data
+
+    async def test_correlation_matrix_returned(
+        self, test_mcp: FastMCP, tmp_path: Path, patch_yfinance
+    ) -> None:
+        path = write_xml(tmp_path, XML_TWO_POSITIONS)
+        result = await call_tool_fn(
+            test_mcp, "analyze_portfolio_correlation", file_path=path, ctx=None
+        )
+        data = json.loads(result)
+
+        assert data["summary"]["num_positions"] == 2
+        assert "correlation_matrix" in data
+        assert "CSPX" in data["correlation_matrix"]
+        assert "position_weights" in data
+
+    async def test_invalid_period_raises(self, test_mcp: FastMCP, tmp_path: Path) -> None:
+        path = write_xml(tmp_path, XML_TWO_POSITIONS)
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "analyze_portfolio_correlation",
+                file_path=path,
+                period="bogus",
+                ctx=None,
+            )

--- a/tests/mcp/test_position_history.py
+++ b/tests/mcp/test_position_history.py
@@ -1,0 +1,234 @@
+"""Tests for the position history MCP tools (SQLite-backed).
+
+Uses a real ``PositionStore`` populated at a temp DB path (per testing rules:
+storage uses the real class, not mocks). Each tool is called with that same
+``db_path`` so it reads what we wrote.
+"""
+
+import json
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.exceptions import ValidationError
+from ib_sec_mcp.mcp.tools.position_history import register_position_history_tools
+from ib_sec_mcp.models.account import Account, CashBalance
+from ib_sec_mcp.models.position import Position
+from ib_sec_mcp.models.trade import AssetClass
+from ib_sec_mcp.storage.position_store import PositionStore
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+ACCOUNT_ID = "U1234567"
+SNAP_DATE_1 = date(2025, 1, 31)
+SNAP_DATE_2 = date(2025, 2, 28)
+
+
+def make_position(
+    symbol: str = "AAPL",
+    asset_class: AssetClass = AssetClass.STOCK,
+    quantity: str = "10",
+    mark_price: str = "150.00",
+    position_value: str = "1500.00",
+    cost_basis: str = "1400.00",
+    average_cost: str = "140.00",
+    unrealized_pnl: str = "100.00",
+) -> Position:
+    return Position(
+        account_id=ACCOUNT_ID,
+        symbol=symbol,
+        description=f"{symbol} Inc",
+        asset_class=asset_class,
+        quantity=Decimal(quantity),
+        mark_price=Decimal(mark_price),
+        position_value=Decimal(position_value),
+        average_cost=Decimal(average_cost),
+        cost_basis=Decimal(cost_basis),
+        unrealized_pnl=Decimal(unrealized_pnl),
+        currency="USD",
+        fx_rate_to_base=Decimal("1.0"),
+        position_date=SNAP_DATE_1,
+    )
+
+
+def make_account(
+    positions: list[Position] | None = None,
+    from_date: date = SNAP_DATE_1,
+    to_date: date = SNAP_DATE_1,
+) -> Account:
+    return Account(
+        account_id=ACCOUNT_ID,
+        from_date=from_date,
+        to_date=to_date,
+        cash_balances=[
+            CashBalance(
+                currency="USD",
+                starting_cash=Decimal("1000"),
+                ending_cash=Decimal("1000"),
+                ending_settled_cash=Decimal("1000"),
+            )
+        ],
+        positions=positions or [],
+    )
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    register_position_history_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Create a populated positions DB and return its path string."""
+    path = tmp_path / "positions.db"
+    store = PositionStore(path)
+    # Two snapshots of AAPL + a second symbol on date 1.
+    store.save_snapshot(
+        make_account(
+            positions=[
+                make_position(symbol="AAPL", mark_price="150", position_value="1500"),
+                make_position(symbol="MSFT", mark_price="300", position_value="3000"),
+            ]
+        ),
+        SNAP_DATE_1,
+        "/data/jan.xml",
+    )
+    store.save_snapshot(
+        make_account(
+            positions=[make_position(symbol="AAPL", mark_price="160", position_value="1600")],
+            from_date=SNAP_DATE_2,
+            to_date=SNAP_DATE_2,
+        ),
+        SNAP_DATE_2,
+        "/data/feb.xml",
+    )
+    store.close()
+    return str(path)
+
+
+class TestGetPositionHistory:
+    async def test_returns_snapshots_for_symbol(self, test_mcp: FastMCP, db_path: str) -> None:
+        result = await call_tool_fn(
+            test_mcp,
+            "get_position_history",
+            account_id=ACCOUNT_ID,
+            symbol="AAPL",
+            start_date="2025-01-01",
+            end_date="2025-03-01",
+            db_path=db_path,
+            ctx=None,
+        )
+        data = json.loads(result)
+        assert data["snapshot_count"] == 2
+        assert len(data["snapshots"]) == 2
+        assert data["symbol"] == "AAPL"
+
+    async def test_empty_range_returns_message(self, test_mcp: FastMCP, db_path: str) -> None:
+        result = await call_tool_fn(
+            test_mcp,
+            "get_position_history",
+            account_id=ACCOUNT_ID,
+            symbol="NVDA",
+            start_date="2025-01-01",
+            end_date="2025-03-01",
+            db_path=db_path,
+            ctx=None,
+        )
+        data = json.loads(result)
+        assert data["snapshots"] == []
+        assert "message" in data
+
+    async def test_invalid_date_raises_validation_error(
+        self, test_mcp: FastMCP, db_path: str
+    ) -> None:
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "get_position_history",
+                account_id=ACCOUNT_ID,
+                symbol="AAPL",
+                start_date="not-a-date",
+                end_date="2025-03-01",
+                db_path=db_path,
+                ctx=None,
+            )
+
+
+class TestGetPortfolioSnapshot:
+    async def test_returns_positions_and_totals(self, test_mcp: FastMCP, db_path: str) -> None:
+        result = await call_tool_fn(
+            test_mcp,
+            "get_portfolio_snapshot",
+            account_id=ACCOUNT_ID,
+            snapshot_date="2025-01-31",
+            db_path=db_path,
+            ctx=None,
+        )
+        data = json.loads(result)
+        assert data["position_count"] == 2
+        # total_value serialized as string via default=str; AAPL 1500 + MSFT 3000.
+        assert Decimal(str(data["total_value"])) == Decimal("4500")
+
+    async def test_invalid_date_raises(self, test_mcp: FastMCP, db_path: str) -> None:
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "get_portfolio_snapshot",
+                account_id=ACCOUNT_ID,
+                snapshot_date="2025/01/31",
+                db_path=db_path,
+                ctx=None,
+            )
+
+
+class TestComparePortfolioSnapshots:
+    async def test_compare_detects_removed_symbol(self, test_mcp: FastMCP, db_path: str) -> None:
+        result = await call_tool_fn(
+            test_mcp,
+            "compare_portfolio_snapshots",
+            account_id=ACCOUNT_ID,
+            date1="2025-01-31",
+            date2="2025-02-28",
+            db_path=db_path,
+            ctx=None,
+        )
+        data = json.loads(result)
+        # MSFT present on date1 only -> removed.
+        assert "MSFT" in data["positions_removed"]
+
+
+class TestGetPositionStatistics:
+    async def test_statistics_min_max(self, test_mcp: FastMCP, db_path: str) -> None:
+        result = await call_tool_fn(
+            test_mcp,
+            "get_position_statistics",
+            account_id=ACCOUNT_ID,
+            symbol="AAPL",
+            start_date="2025-01-01",
+            end_date="2025-03-01",
+            db_path=db_path,
+            ctx=None,
+        )
+        data = json.loads(result)
+        assert data["snapshot_count"] == 2
+        assert Decimal(str(data["price_statistics"]["min"])) == Decimal("150")
+        assert Decimal(str(data["price_statistics"]["max"])) == Decimal("160")
+
+
+class TestGetAvailableSnapshotDates:
+    async def test_lists_available_dates(self, test_mcp: FastMCP, db_path: str) -> None:
+        result = await call_tool_fn(
+            test_mcp,
+            "get_available_snapshot_dates",
+            account_id=ACCOUNT_ID,
+            db_path=db_path,
+            ctx=None,
+        )
+        data = json.loads(result)
+        assert data["snapshot_count"] == 2
+        assert "2025-01-31" in data["available_dates"]
+        assert "2025-02-28" in data["available_dates"]

--- a/tests/mcp/test_resources.py
+++ b/tests/mcp/test_resources.py
@@ -1,0 +1,208 @@
+"""Tests for IB Analytics MCP resources.
+
+Covers the read-only resources backed by ``data/raw`` XML files and the user
+profile YAML. Resource handlers read from the current working directory, so tests
+``chdir`` into a temp dir and stage ``data/raw`` / ``notes`` as needed.
+
+Note: the rebalancing target-allocation precedence logic is covered separately in
+``test_resources_rebalancing.py``; here we verify the resource payload shapes.
+"""
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.resources import (
+    RESOURCE_PORTFOLIO_LATEST,
+    RESOURCE_PORTFOLIO_LIST,
+    RESOURCE_POSITIONS_CURRENT,
+    RESOURCE_STRATEGY_REBALANCING,
+    RESOURCE_STRATEGY_RISK,
+    RESOURCE_STRATEGY_TAX,
+    RESOURCE_TRADES_RECENT,
+    RESOURCE_USER_PROFILE,
+    register_resources,
+)
+
+ACCOUNT_ID = "U1234567"
+XML_NAME = "U1234567_2025-01-01_2025-06-30.xml"
+
+# Portfolio with a gain (CSPX) + a loss (EEM, for tax loss harvesting) and two trades.
+PORTFOLIO_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="test" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20250630">
+      <AccountInformation accountId="U1234567" acctAlias="Test Account" />
+      <CashReport>
+        <CashReportCurrency currency="BASE_SUMMARY"
+          startingCash="5000" endingCash="5000" endingSettledCash="5000" />
+      </CashReport>
+      <OpenPositions>
+        <OpenPosition symbol="CSPX" description="ISHARES CORE S&amp;P 500"
+          assetCategory="STK" currency="USD" fxRateToBase="1"
+          isin="IE00B5BMR087" position="10" markPrice="735.00"
+          positionValue="7350" costBasisMoney="6000" fifoPnlUnrealized="1350"
+          reportDate="20250630" multiplier="1" />
+        <OpenPosition symbol="EEM" description="ISHARES MSCI EMERGING MARKETS"
+          assetCategory="STK" currency="USD" fxRateToBase="1"
+          isin="US4642872349" position="200" markPrice="38.00"
+          positionValue="7600" costBasisMoney="9000" fifoPnlUnrealized="-1400"
+          reportDate="20250630" multiplier="1" />
+      </OpenPositions>
+      <Trades>
+        <Trade tradeID="T001" accountId="U1234567" symbol="CSPX"
+          description="ISHARES CORE S&amp;P 500" assetCategory="STK"
+          currency="USD" fxRateToBase="1"
+          buySell="BUY" quantity="10" tradePrice="600.00"
+          tradeMoney="-6000" ibCommission="-1.00" ibCommissionCurrency="USD"
+          tradeDate="20250301" settleDate="20250303"
+          fifoPnlRealized="0" mtmPnl="0" multiplier="1"
+          orderID="O001" execID="E001" />
+        <Trade tradeID="T002" accountId="U1234567" symbol="EEM"
+          description="ISHARES MSCI EMERGING MARKETS" assetCategory="STK"
+          currency="USD" fxRateToBase="1"
+          buySell="BUY" quantity="200" tradePrice="45.00"
+          tradeMoney="-9000" ibCommission="-1.00" ibCommissionCurrency="USD"
+          tradeDate="20250115" settleDate="20250117"
+          fifoPnlRealized="0" mtmPnl="0" multiplier="1"
+          orderID="O002" execID="E002" />
+      </Trades>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>"""
+
+
+async def _maybe_await(value: object) -> object:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def read_resource(mcp: FastMCP, uri: str) -> str:
+    """Read a static resource's text content."""
+    res = await _maybe_await(mcp.get_resource(uri))
+    return await _maybe_await(res.read())
+
+
+async def read_account_resource(mcp: FastMCP, account_id: str) -> str:
+    """Invoke the ``ib://accounts/{account_id}`` template handler."""
+    templates = await _maybe_await(mcp.list_resource_templates())
+    assert templates, "expected an account resource template"
+    return await _maybe_await(templates[0].fn(account_id=account_id))
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    register_resources(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def with_portfolio(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """chdir into tmp_path with a populated data/raw directory."""
+    monkeypatch.chdir(tmp_path)
+    raw = tmp_path / "data" / "raw"
+    raw.mkdir(parents=True)
+    (raw / XML_NAME).write_text(PORTFOLIO_XML)
+    return tmp_path
+
+
+@pytest.fixture()
+def empty_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestPortfolioListAndLatest:
+    async def test_list_no_data_dir(self, test_mcp: FastMCP, empty_cwd: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_PORTFOLIO_LIST))
+        assert data["files"] == []
+
+    async def test_list_returns_files(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_PORTFOLIO_LIST))
+        assert data["count"] == 1
+        assert data["files"][0]["filename"] == XML_NAME
+
+    async def test_latest_no_data_dir(self, test_mcp: FastMCP, empty_cwd: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_PORTFOLIO_LATEST))
+        assert "error" in data
+
+    async def test_latest_summary(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_PORTFOLIO_LATEST))
+        assert data["account_id"] == ACCOUNT_ID
+        assert data["num_positions"] == 2
+        assert data["file"] == XML_NAME
+
+
+class TestAccountResource:
+    async def test_account_data(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_account_resource(test_mcp, ACCOUNT_ID))
+        assert data["account_id"] == ACCOUNT_ID
+        assert "total_value" in data
+
+    async def test_unknown_account_returns_error(
+        self, test_mcp: FastMCP, with_portfolio: Path
+    ) -> None:
+        data = json.loads(await read_account_resource(test_mcp, "U9999999"))
+        assert "error" in data
+
+
+class TestTradesAndPositions:
+    async def test_recent_trades(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_TRADES_RECENT))
+        assert data["count"] == 2
+        symbols = {t["symbol"] for t in data["trades"]}
+        assert symbols == {"CSPX", "EEM"}
+
+    async def test_current_positions(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_POSITIONS_CURRENT))
+        assert data["count"] == 2
+        position = data["positions"][0]
+        assert "market_value" in position
+        assert "unrealized_pnl" in position
+
+
+class TestStrategyResources:
+    async def test_tax_context_has_loss_harvesting(
+        self, test_mcp: FastMCP, with_portfolio: Path
+    ) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_STRATEGY_TAX))
+        assert "tax_lot_summary" in data
+        assert "wash_sale_warnings" in data
+        # EEM has an unrealized loss -> a loss harvesting opportunity.
+        symbols = {o["symbol"] for o in data["tax_loss_harvesting_opportunities"]}
+        assert "EEM" in symbols
+
+    async def test_rebalancing_context_shape(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_STRATEGY_REBALANCING))
+        assert set(data["current_allocation"]) == {"BOND", "STK", "CASH"}
+        assert "drift_analysis" in data
+        assert isinstance(data["rebalancing_needed"], bool)
+
+    async def test_risk_context_shape(self, test_mcp: FastMCP, with_portfolio: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_STRATEGY_RISK))
+        assert "portfolio_risk_metrics" in data
+        assert "interest_rate_scenarios" in data
+        assert "liquidity_risk" in data
+
+
+class TestUserProfile:
+    async def test_profile_missing_returns_error(self, test_mcp: FastMCP, empty_cwd: Path) -> None:
+        data = json.loads(await read_resource(test_mcp, RESOURCE_USER_PROFILE))
+        assert data["error"] == "Profile not found"
+
+    async def test_profile_returned(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        notes = tmp_path / "notes"
+        notes.mkdir()
+        (notes / "investor-profile.yaml").write_text(
+            "residency:\n  country: Malaysia\ninvestment_profile:\n  type: balanced\n"
+        )
+        data = json.loads(await read_resource(test_mcp, RESOURCE_USER_PROFILE))
+        assert data["residency"]["country"] == "Malaysia"

--- a/tests/mcp/test_sentiment_analysis.py
+++ b/tests/mcp/test_sentiment_analysis.py
@@ -1,0 +1,163 @@
+"""Tests for the ``analyze_market_sentiment`` MCP tool.
+
+The underlying analyzers hit the network (news/options/technical), so they are
+patched to return deterministic ``SentimentScore`` objects. Tests focus on the
+tool's own logic: source routing, interpretation thresholds, validation, timeout
+handling, and error masking (no internal error detail leaked to the caller).
+"""
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+
+import ib_sec_mcp.mcp.tools.sentiment_analysis as sentiment_module
+from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
+from ib_sec_mcp.mcp.exceptions import IBTimeoutError, ValidationError
+from ib_sec_mcp.mcp.tools.sentiment_analysis import register_sentiment_analysis_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+
+def make_score(score: str, confidence: str = "0.8") -> SentimentScore:
+    return SentimentScore(
+        score=Decimal(score),
+        confidence=Decimal(confidence),
+        timestamp=datetime(2026, 1, 1, 12, 0, 0),
+        key_themes=["theme_a"],
+        risk_factors=["risk_a"],
+        reasoning="test reasoning",
+    )
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    register_sentiment_analysis_tools(mcp)
+    return mcp
+
+
+def _patch_analyzer(
+    monkeypatch: pytest.MonkeyPatch, class_name: str, score: SentimentScore
+) -> None:
+    """Patch ``<Analyzer>.analyze_sentiment`` to return a fixed score."""
+    cls = getattr(sentiment_module, class_name)
+    monkeypatch.setattr(cls, "analyze_sentiment", AsyncMock(return_value=score))
+
+
+class TestSourceRouting:
+    async def test_news_source_returns_expected_payload(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_analyzer(monkeypatch, "NewsSentimentAnalyzer", make_score("0.3"))
+        result = await call_tool_fn(
+            test_mcp, "analyze_market_sentiment", symbol="AAPL", sources="news", ctx=None
+        )
+        data = json.loads(result)
+        assert data["symbol"] == "AAPL"
+        assert data["sources_analyzed"] == ["news"]
+        assert data["sentiment_score"] == pytest.approx(0.3)
+        assert data["key_themes"] == ["theme_a"]
+
+    async def test_technical_source(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_analyzer(monkeypatch, "TechnicalSentimentAnalyzer", make_score("0.0"))
+        result = await call_tool_fn(
+            test_mcp, "analyze_market_sentiment", symbol="TSLA", sources="technical", ctx=None
+        )
+        data = json.loads(result)
+        assert data["sources_analyzed"] == ["technical"]
+
+    async def test_composite_source_uses_composite_analyzer(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_analyzer(monkeypatch, "CompositeSentimentAnalyzer", make_score("0.6"))
+        result = await call_tool_fn(
+            test_mcp, "analyze_market_sentiment", symbol="SPY", sources="composite", ctx=None
+        )
+        data = json.loads(result)
+        assert data["interpretation"] == "Strong Bullish"
+
+    async def test_multiple_sources_routes_to_composite(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # "news,options" (len > 1) must use the composite analyzer.
+        _patch_analyzer(monkeypatch, "CompositeSentimentAnalyzer", make_score("0.1"))
+        result = await call_tool_fn(
+            test_mcp, "analyze_market_sentiment", symbol="AAPL", sources="news,options", ctx=None
+        )
+        data = json.loads(result)
+        assert data["sources_analyzed"] == ["news", "options"]
+
+
+class TestInterpretation:
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            ("0.6", "Strong Bullish"),
+            ("0.3", "Moderately Bullish"),
+            ("0.0", "Neutral"),
+            ("-0.3", "Moderately Bearish"),
+            ("-0.6", "Strong Bearish"),
+        ],
+    )
+    async def test_interpretation_thresholds(
+        self,
+        test_mcp: FastMCP,
+        monkeypatch: pytest.MonkeyPatch,
+        score: str,
+        expected: str,
+    ) -> None:
+        _patch_analyzer(monkeypatch, "NewsSentimentAnalyzer", make_score(score))
+        result = await call_tool_fn(
+            test_mcp, "analyze_market_sentiment", symbol="AAPL", sources="news", ctx=None
+        )
+        assert json.loads(result)["interpretation"] == expected
+
+
+class TestValidation:
+    async def test_invalid_symbol_raises_validation_error(self, test_mcp: FastMCP) -> None:
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp, "analyze_market_sentiment", symbol="!!!", sources="news", ctx=None
+            )
+
+    @pytest.mark.parametrize("lookback", [0, 366])
+    async def test_lookback_out_of_range_raises(self, test_mcp: FastMCP, lookback: int) -> None:
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp,
+                "analyze_market_sentiment",
+                symbol="AAPL",
+                lookback_days=lookback,
+                sources="news",
+                ctx=None,
+            )
+
+
+class TestErrorHandling:
+    async def test_timeout_raises_ib_timeout_error(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cls = sentiment_module.NewsSentimentAnalyzer
+        monkeypatch.setattr(cls, "analyze_sentiment", AsyncMock(side_effect=TimeoutError("slow")))
+        with pytest.raises(IBTimeoutError):
+            await call_tool_fn(
+                test_mcp, "analyze_market_sentiment", symbol="AAPL", sources="news", ctx=None
+            )
+
+    async def test_internal_error_is_masked(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        secret = "SECRET_DB_CONNECTION_STRING"
+        cls = sentiment_module.NewsSentimentAnalyzer
+        monkeypatch.setattr(cls, "analyze_sentiment", AsyncMock(side_effect=RuntimeError(secret)))
+        with pytest.raises(ValidationError) as exc_info:
+            await call_tool_fn(
+                test_mcp, "analyze_market_sentiment", symbol="AAPL", sources="news", ctx=None
+            )
+        # Internal error detail must not leak into the surfaced error message.
+        assert secret not in str(exc_info.value)

--- a/tests/tools/test_etf_calculator.py
+++ b/tests/tools/test_etf_calculator.py
@@ -1,0 +1,200 @@
+"""Tests for the pure ETF swap calculation logic.
+
+Covers ``ETFSwapCalculator`` (single + portfolio swaps) and ``validate_etf_price``.
+All calculations are Decimal-based; these tests guard arithmetic correctness and
+the payback-period edge cases (no benefit -> infinity).
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from ib_sec_mcp.tools.etf_calculator import (
+    ETFSwapCalculator,
+    SwapCalculation,
+    validate_etf_price,
+)
+
+# A realistic TLT -> IDTL swap (lower withholding tax, lower expense ratio).
+SWAP_KWARGS = {
+    "from_symbol": "TLT",
+    "from_shares": 200,
+    "from_price": Decimal("91.34"),
+    "from_expense_ratio": Decimal("0.0015"),
+    "from_dividend_yield": Decimal("0.0433"),
+    "from_withholding_tax": Decimal("0.30"),
+    "to_symbol": "IDTL",
+    "to_price": Decimal("3.40"),
+    "to_expense_ratio": Decimal("0.0007"),
+    "to_dividend_yield": Decimal("0.0445"),
+    "to_withholding_tax": Decimal("0.15"),
+}
+
+
+class TestCalculateSwap:
+    def test_required_shares_rounded_half_up(self) -> None:
+        calc = ETFSwapCalculator().calculate_swap(**SWAP_KWARGS)
+        # from_total = 200 * 91.34 = 18268.00 ; 18268.00 / 3.40 = 5372.94 -> 5373
+        assert calc.required_shares == 5373
+
+    def test_purchase_amount_and_surplus_are_exact_decimal(self) -> None:
+        calc = ETFSwapCalculator().calculate_swap(**SWAP_KWARGS)
+        assert calc.purchase_amount == Decimal("18268.20")  # 5373 * 3.40
+        assert calc.from_etf.total_value == Decimal("18268.00")  # 200 * 91.34
+        assert calc.surplus_cash == Decimal("-0.20")  # from_total - purchase
+
+    def test_positive_net_benefit_gives_finite_payback(self) -> None:
+        calc = ETFSwapCalculator().calculate_swap(**SWAP_KWARGS)
+        assert calc.annual_net_benefit > 0
+        assert calc.payback_period_months != float("inf")
+        assert calc.payback_period_months > 0
+
+    def test_financial_fields_are_decimal(self) -> None:
+        calc = ETFSwapCalculator().calculate_swap(**SWAP_KWARGS)
+        assert isinstance(calc.purchase_amount, Decimal)
+        assert isinstance(calc.surplus_cash, Decimal)
+        assert isinstance(calc.annual_withholding_tax_savings, Decimal)
+        assert isinstance(calc.annual_net_benefit, Decimal)
+
+    def test_no_benefit_swap_returns_infinite_payback(self) -> None:
+        """A swap into a worse ETF (higher tax + higher expense) yields no benefit."""
+        calc = ETFSwapCalculator().calculate_swap(
+            from_symbol="GOOD",
+            from_shares=100,
+            from_price=Decimal("100"),
+            from_expense_ratio=Decimal("0.0003"),
+            from_dividend_yield=Decimal("0.02"),
+            from_withholding_tax=Decimal("0.00"),
+            to_symbol="BAD",
+            to_price=Decimal("100"),
+            to_expense_ratio=Decimal("0.0015"),
+            to_dividend_yield=Decimal("0.02"),
+            to_withholding_tax=Decimal("0.30"),
+        )
+        assert calc.annual_net_benefit <= 0
+        assert calc.payback_period_months == float("inf")
+
+    def test_custom_trading_fee_changes_payback(self) -> None:
+        cheap = ETFSwapCalculator(trading_fee_usd=Decimal("10")).calculate_swap(**SWAP_KWARGS)
+        pricey = ETFSwapCalculator(trading_fee_usd=Decimal("150")).calculate_swap(**SWAP_KWARGS)
+        # Higher trading fee => longer payback period.
+        assert pricey.payback_period_months > cheap.payback_period_months
+
+
+class TestFormatCalculationResult:
+    def test_format_includes_symbols_and_shares(self) -> None:
+        calc = ETFSwapCalculator().calculate_swap(**SWAP_KWARGS)
+        out = ETFSwapCalculator().format_calculation_result(calc)
+        assert "TLT" in out
+        assert "IDTL" in out
+        assert "5,373" in out  # required shares, formatted with thousands separator
+
+    def test_format_infinite_payback_message(self) -> None:
+        calc = ETFSwapCalculator().calculate_swap(
+            from_symbol="GOOD",
+            from_shares=100,
+            from_price=Decimal("100"),
+            from_expense_ratio=Decimal("0.0003"),
+            from_dividend_yield=Decimal("0.02"),
+            from_withholding_tax=Decimal("0.00"),
+            to_symbol="BAD",
+            to_price=Decimal("100"),
+            to_expense_ratio=Decimal("0.0015"),
+            to_dividend_yield=Decimal("0.02"),
+            to_withholding_tax=Decimal("0.30"),
+        )
+        out = ETFSwapCalculator().format_calculation_result(calc)
+        assert "メリットなし" in out
+
+
+class TestCalculatePortfolioSwap:
+    def test_summary_aggregates_individual_swaps(self) -> None:
+        swaps = [
+            {
+                "from_symbol": "TLT",
+                "from_shares": 200,
+                "from_price": 91.34,
+                "from_expense_ratio": 0.0015,
+                "from_dividend_yield": 0.0433,
+                "from_withholding_tax": 0.30,
+                "to_symbol": "IDTL",
+                "to_price": 3.40,
+                "to_expense_ratio": 0.0007,
+                "to_dividend_yield": 0.0445,
+                "to_withholding_tax": 0.15,
+            },
+            {
+                "from_symbol": "VOO",
+                "from_shares": 40,
+                "from_price": 607.39,
+                "from_expense_ratio": 0.0003,
+                "from_dividend_yield": 0.0115,
+                "from_withholding_tax": 0.30,
+                "to_symbol": "CSPX",
+                "to_price": 714.78,
+                "to_expense_ratio": 0.0007,
+                "to_dividend_yield": 0.0115,
+                "to_withholding_tax": 0.00,
+            },
+        ]
+        result = ETFSwapCalculator().calculate_portfolio_swap(swaps)
+
+        assert len(result["individual_results"]) == 2
+        assert all(isinstance(c, SwapCalculation) for c in result["individual_results"])
+
+        summary = result["summary"]
+        assert summary["total_from_shares"] == 240  # 200 + 40
+        assert summary["total_to_shares"] == (
+            result["individual_results"][0].required_shares
+            + result["individual_results"][1].required_shares
+        )
+        assert summary["trading_fee"] == 75.0
+        # Net benefit should equal savings minus expense change.
+        assert summary["annual_net_benefit"] == pytest.approx(
+            summary["annual_withholding_savings"] - summary["annual_expense_change"]
+        )
+
+    def test_empty_portfolio_has_zero_totals_and_infinite_payback(self) -> None:
+        result = ETFSwapCalculator().calculate_portfolio_swap([])
+        assert result["individual_results"] == []
+        assert result["summary"]["total_from_shares"] == 0
+        assert result["summary"]["payback_period_months"] == float("inf")
+
+
+class TestValidateEtfPrice:
+    def test_normal_price_is_valid_no_warnings(self) -> None:
+        result = validate_etf_price("CSPX", Decimal("700.00"))
+        assert result["is_valid"] is True
+        assert result["warnings"] == []
+
+    def test_low_price_warns_and_is_invalid(self) -> None:
+        result = validate_etf_price("PENNY", Decimal("0.50"))
+        assert result["is_valid"] is False
+        assert any("⚠️" in w for w in result["warnings"])
+
+    def test_high_price_warns(self) -> None:
+        result = validate_etf_price("EXPENSIVE", Decimal("1500.00"))
+        assert result["is_valid"] is False
+        assert any("⚠️" in w for w in result["warnings"])
+
+    def test_reference_ratio_extreme_flags_error(self) -> None:
+        # 200x the reference price -> data error warning (⚠️).
+        result = validate_etf_price(
+            "WEIRD",
+            Decimal("200.00"),
+            reference_symbol="REF",
+            reference_price=Decimal("1.00"),
+        )
+        assert result["price_ratio"] == 200.0
+        assert result["is_valid"] is False
+
+    def test_reference_ratio_informational_only(self) -> None:
+        # 0.3x ratio (different per-share design) -> informational (ℹ️) note, still valid.
+        result = validate_etf_price(
+            "DESIGN",
+            Decimal("30.00"),
+            reference_symbol="REF",
+            reference_price=Decimal("100.00"),
+        )
+        assert result["is_valid"] is True
+        assert any("ℹ️" in w for w in result["warnings"])


### PR DESCRIPTION
## Summary

Resolves #124 (Wave 3, `test` / `parallel-safe`).

Adds unit tests for MCP tools and security-adjacent modules that previously had **0% or minimal** coverage. No production source was modified — purely test additions within the files this issue owns.

## New test files

| Test file | Target module | What it covers |
|---|---|---|
| `tests/mcp/test_portfolio_analytics.py` | `portfolio_analytics.py` | sharpe/beta/correlation happy path (yfinance mocked) + validation/early-exit branches |
| `tests/mcp/test_position_history.py` | `position_history.py` | all 5 tools against a real `PositionStore` SQLite fixture + invalid-date handling |
| `tests/mcp/test_etf_calculator_tools.py` | `etf_calculator_tools.py` | swap/portfolio-swap wrappers, trading-fee env resolution, payback null serialization |
| `tests/tools/test_etf_calculator.py` | `tools/etf_calculator.py` | pure Decimal swap math, infinite-payback edge case, `validate_etf_price` |
| `tests/mcp/test_sentiment_analysis.py` | `sentiment_analysis.py` | source routing, interpretation thresholds, timeout → `IBTimeoutError`, error masking |
| `tests/analyzers/sentiment/test_technical.py` | `analyzers/sentiment/technical.py` | RSI/MACD helpers + trend branches + graceful degradation |
| `tests/mcp/test_middleware.py` | `mcp/middleware.py` | error tracking, retry exponential backoff, **no-secret-leak verification** |
| `tests/mcp/test_resources.py` | `mcp/resources.py` | content of the 9 resources + no-data error branches |

## Coverage gains

| Module | Before | After |
|---|---|---|
| portfolio_analytics.py | 0% | 81% |
| position_history.py | 0% | 61% |
| etf_calculator_tools.py | 0% | 100% |
| sentiment_analysis.py | 0% | 87% |
| tools/etf_calculator.py | 26% | 97% |
| middleware.py | 25% | 97% |
| resources.py | 16% | 78% |
| sentiment/technical.py | 0% | 85% |

## Acceptance criteria

- [x] Coverage of target modules increased
- [x] Middleware confidential-data masking explicitly verified (logging middleware does not leak request payloads/secrets)
- [x] Green — full suite **1068 passed**

## Notes

- `sentiment/options.py` source is intentionally **not** touched (owned by #CLEANUP); per the issue, only `test_technical.py` is added under `tests/analyzers/sentiment/`.
- Tests follow existing conventions (`_fastmcp_helpers.call_tool_fn`, real storage classes via `tmp_path`, yfinance patched at module level, Decimal-based financial assertions).

## Testing

```
uv run pytest        # 1068 passed, total coverage 67%
uv run ruff check ib_sec_mcp tests   # clean
uv run ruff format --check           # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)