### PR TITLE
docs(sync): fix module/tool/command counts in architecture, CHANGELOG and .claude docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -191,7 +191,7 @@ uv run pytest --cov=ib_sec_mcp
 
 ## MCP Server Quick Reference
 
-45 tools, 9 resources, 5 prompts. Full reference: [docs/mcp-tools-reference.md](../docs/mcp-tools-reference.md)
+59 tools (51 default + 8 live-trading tools gated behind `IB_ENABLE_LIVE_TRADING`), 9 resources, 5 prompts. Full reference: [docs/mcp-tools-reference.md](../docs/mcp-tools-reference.md)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,24 @@ All notable changes to this project will be documented in this file.
 
 - **`FlexQueryClient`** (#120): extracted duplicated SendRequest XML parsing into a shared `_parse_send_request_response()` helper (no behavior change)
 
+### Fixed
+
+- **Position pagination & connection errors** (#105): `CPClient` now paginates the
+  positions endpoint (with a `max_pages` safeguard and warning log) and preserves
+  underlying connection errors instead of masking them as empty responses
+
 ### Added
 
+- **Live-trading tools via Client Portal Gateway** (#99, #142): CP Gateway-backed
+  live order/account/position tools (`get_live_orders`, `get_live_account_balance`,
+  `get_live_positions`, etc.), gated behind the `IB_ENABLE_LIVE_TRADING` flag
+  (default off) so they are not advertised to MCP clients unless explicitly enabled
+- **Limit order management** (#80, #100): limit order management table and MCP tools,
+  plus DB sync of locally tracked limit orders against live IB orders via the CP API
+- **Daily monitor tools** (#81) and **`/daily-check` command** (#82, #83): reliable
+  fetch + sync pipeline for scheduled portfolio monitoring with memory-file
+  auto-update rules
+- **Earnings calendar MCP tool** (#115): upcoming earnings dates for a given symbol
 - **Sentiment Analysis Module** (Phase 1-3): Comprehensive market sentiment analysis (#7)
   - **Base Infrastructure**:
     - `SentimentScore` Pydantic model with Decimal precision

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ graph TD
 | File            | Responsibility                                                                                         |
 | --------------- | ------------------------------------------------------------------------------------------------------ |
 | `server.py`     | `create_server()` - FastMCP server factory with middleware chain (logging → retry → error).            |
-| `tools/`        | 12 tool modules providing MCP tools. Coarse-grained (complete analysis) and fine-grained (composable). |
+| `tools/`        | 19 tool modules providing MCP tools. Coarse-grained (complete analysis) and fine-grained (composable). |
 | `resources.py`  | URI-based resource access (`ib://portfolio/latest`, `ib://accounts/{id}`).                             |
 | `prompts.py`    | Pre-configured analysis prompt templates.                                                              |
 | `middleware.py` | Logging, retry, and error handling middleware.                                                         |


### PR DESCRIPTION
## Summary

Syncs documentation counts to actual values and backfills the CHANGELOG. Resolves #127 (Wave 4, docs-only, file-isolated).

## Changes

| File | Change |
| --- | --- |
| `docs/architecture.md` | `tools/` row: **12 → 19** tool modules (actual `ib_sec_mcp/mcp/tools/*.py` count) |
| `.claude/CLAUDE.md` | MCP Quick Reference: **45 → 59 tools** (51 default-registered + 8 live-trading tools gated behind `IB_ENABLE_LIVE_TRADING`); resources/prompts unchanged at 9/5 |
| `CHANGELOG.md` | `[Unreleased]`: backfilled features missing since the sentiment module + new **Fixed** entry |

### CHANGELOG backfill
- **Added**: live-trading tools via CP Gateway (#99, #142), limit order management (#80, #100), daily monitor tools + `/daily-check` (#81, #82, #83), earnings calendar tool (#115)
- **Fixed**: position pagination & connection-error preservation in `CPClient` (#105)

## Count verification (authoritative sources)

- **Tool modules = 19**: `ls ib_sec_mcp/mcp/tools/*.py | grep -v __init__ | wc -l`
- **Tools = 59**: `tests/mcp/test_server.py` → `EXPECTED_TOOLS` (51) + `LIVE_TRADING_TOOLS` (8); matches 59 `@mcp.tool` decorators. Confirmed by existing CHANGELOG `#121` entry ("62 → 59 tools").
- **Resources = 9, Prompts = 5**: unchanged, verified via `@mcp.resource` / `@mcp.prompt`.

## Notes on the "20/21" off-by-one

The issue noted slash-command prose "21" vs "20 files". The repo now has **21** command files (`.claude/commands/*.md`), so prose "21" in `/CLAUDE.md` and `.claude/README.md` is already correct — the off-by-one was resolved upstream when a command was added. Sub-agent count (11) is also already accurate. No edits needed in those two files.

## Out of scope

`docs/mcp-tools-reference.md` still states "45 tools" but is owned by a separate issue (#10/reference) per the Wave-4 file-isolation plan — not touched here.

## Testing

Docs-only change; no code paths affected. No markdown linting configured in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)