### PR TITLE
feat(advisor): add position-decision synthesis tool (#128)

### DIFF
--- a/ib_sec_mcp/mcp/tools/__init__.py
+++ b/ib_sec_mcp/mcp/tools/__init__.py
@@ -41,6 +41,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     from ib_sec_mcp.mcp.tools.portfolio_timeseries import (
         register_portfolio_timeseries_tools,
     )
+    from ib_sec_mcp.mcp.tools.position_advisor import register_position_advisor_tools
     from ib_sec_mcp.mcp.tools.position_history import register_position_history_tools
     from ib_sec_mcp.mcp.tools.rebalancing import register_rebalancing_tools
     from ib_sec_mcp.mcp.tools.sector_fx import register_sector_fx_tools
@@ -65,6 +66,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_technical_analysis_tools(mcp)  # Add technical analysis tools
     register_position_history_tools(mcp)  # Add position history tools
     register_portfolio_timeseries_tools(mcp)  # Add portfolio time-series tools
+    register_position_advisor_tools(mcp)  # Add position decision synthesis tool
     register_etf_calculator_tools(mcp)  # Add ETF calculator tools
     register_sentiment_analysis_tools(mcp)  # Add sentiment analysis tools
     register_rebalancing_tools(mcp)  # Add rebalancing tools

--- a/ib_sec_mcp/mcp/tools/position_advisor.py
+++ b/ib_sec_mcp/mcp/tools/position_advisor.py
@@ -57,6 +57,9 @@ logger = get_logger(__name__)
 # Timeout constants (in seconds)
 DEFAULT_TIMEOUT = 30
 
+# Minimum daily bars required for trend/indicator analysis (SMA-20 needs >= 20).
+_MIN_HISTORY_POINTS = 20
+
 # User investment profile location (same file backing ib://user/profile)
 PROFILE_PATH = Path("notes/investor-profile.yaml")
 
@@ -88,7 +91,7 @@ def _read_user_profile() -> dict[str, Any]:
     if not PROFILE_PATH.exists():
         return {}
     try:
-        with open(PROFILE_PATH) as f:
+        with open(PROFILE_PATH, encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except (yaml.YAMLError, OSError) as e:
         logger.warning("Failed to read user profile: %s", e)
@@ -121,6 +124,11 @@ async def _compute_technical_signals(symbol: str) -> dict[str, Any]:
 
     if hist is None or hist.empty:
         raise YahooFinanceError(f"No price history found for {symbol}")
+    if len(hist) < _MIN_HISTORY_POINTS:
+        raise YahooFinanceError(
+            f"Insufficient price history for {symbol}: {len(hist)} rows "
+            f"(need at least {_MIN_HISTORY_POINTS} for trend/indicator analysis)"
+        )
 
     close = hist["Close"]
     support_resistance = _find_support_resistance(hist)
@@ -197,10 +205,10 @@ def _is_chasing(tech: dict[str, Any]) -> bool:
     True when price sits near resistance or RSI is overbought — situations the
     user explicitly wants to avoid following.
     """
-    sr = tech.get("support_resistance", {})
+    sr = tech.get("support_resistance") or {}
     if sr.get("current_level") == "near_resistance":
         return True
-    rsi = tech.get("indicators", {}).get("rsi", {})
+    rsi = (tech.get("indicators") or {}).get("rsi") or {}
     return bool(rsi.get("signal") == "overbought")
 
 
@@ -213,7 +221,7 @@ def _synthesize_recommendation(
     Returns a dict with ``recommendation``, ``conviction`` (composite score),
     ``technical_score``, ``sentiment_score`` and a ``rationale`` list.
     """
-    signals = tech.get("signals", {})
+    signals = tech.get("signals") or {}
     technical_score = float(signals.get("score", 0.0))
 
     sentiment_score = 0.0
@@ -435,7 +443,7 @@ def _build_portfolio_fit(
                 f"Candidate size {candidate_size:,.0f} is ~{size_pct:.2f}% of your "
                 f"~{float(total_value):,.0f} external holdings."
             )
-        except (TypeError, ZeroDivisionError, ArithmeticError):
+        except (TypeError, ValueError, ZeroDivisionError, ArithmeticError):
             size_pct = None
 
     notes.append(
@@ -537,7 +545,7 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
             decision = _synthesize_recommendation(tech, sentiment)
             staged_entry = _build_staged_entry(
                 current_price=float(current_price),
-                support_resistance=tech.get("support_resistance", {}),
+                support_resistance=tech.get("support_resistance") or {},
                 candidate_size=candidate_size,
                 recommendation=decision["recommendation"],
                 chasing_risk=decision["chasing_risk"],
@@ -547,7 +555,10 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
                 stock_ctx=stock_ctx, candidate_size=candidate_size, profile=profile
             )
 
-            signals = tech.get("signals", {})
+            signals = tech.get("signals") or {}
+            support_resistance = tech.get("support_resistance") or {}
+            indicators = tech.get("indicators") or {}
+            trend = tech.get("trend") or {}
             result: dict[str, Any] = {
                 "symbol": symbol,
                 "as_of": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -560,13 +571,11 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
                     "score": decision["technical_score"],
                     "signal": signals.get("recommendation"),
                     "signals": signals.get("signals", []),
-                    "current_level": tech.get("support_resistance", {}).get("current_level"),
-                    "nearest_support": tech.get("support_resistance", {}).get("nearest_support"),
-                    "nearest_resistance": tech.get("support_resistance", {}).get(
-                        "nearest_resistance"
-                    ),
-                    "rsi": tech.get("indicators", {}).get("rsi"),
-                    "trend": tech.get("trend", {}).get("trend_strength"),
+                    "current_level": support_resistance.get("current_level"),
+                    "nearest_support": support_resistance.get("nearest_support"),
+                    "nearest_resistance": support_resistance.get("nearest_resistance"),
+                    "rsi": indicators.get("rsi"),
+                    "trend": trend.get("trend_strength"),
                 },
                 "sentiment": (
                     {

--- a/ib_sec_mcp/mcp/tools/position_advisor.py
+++ b/ib_sec_mcp/mcp/tools/position_advisor.py
@@ -1,0 +1,612 @@
+"""Position Advisor Tool
+
+Synthesizes existing analyzers and data sources into a single, actionable
+position decision for a *candidate* symbol:
+
+- **Technicals**: support/resistance, trend, RSI/MACD/ADX/ATR, trading signals
+  (reuses the helpers behind ``get_stock_analysis`` — no indicator math is
+  re-implemented here).
+- **Sentiment**: news sentiment via ``NewsSentimentAnalyzer``.
+- **Valuation / info**: sector, P/E, dividend yield, beta, 52-week range
+  (Yahoo Finance ``Ticker.info``).
+- **Tax / FX**: Malaysia-resident withholding considerations and
+  Ireland-domiciled ETF alternatives (``ETF_ALTERNATIVES``).
+- **Staged entry**: 3-4 tranche accumulation plan that respects the user's
+  "don't chase bounces" rule.
+- **Portfolio fit**: target-allocation guidance derived from the user profile
+  (``ib://user/profile`` → ``notes/investor-profile.yaml``).
+
+The tool is composition-only: it orchestrates existing building blocks and adds
+explicit decision logic (IE-domicile preference, staged entry, chase-avoidance).
+It degrades gracefully — sentiment and valuation are best-effort, while price
+history is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastmcp import Context, FastMCP
+
+from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
+from ib_sec_mcp.analyzers.sentiment.news import NewsSentimentAnalyzer
+from ib_sec_mcp.mcp.exceptions import (
+    IBAnalyticsError,
+    IBTimeoutError,
+    ValidationError,
+    YahooFinanceError,
+)
+from ib_sec_mcp.mcp.tools.ib_portfolio import ETF_ALTERNATIVES
+from ib_sec_mcp.mcp.tools.technical_analysis import (
+    _analyze_trends,
+    _analyze_volume,
+    _calculate_indicators,
+    _find_support_resistance,
+    _generate_signals,
+)
+from ib_sec_mcp.mcp.validators import validate_symbol
+from ib_sec_mcp.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Timeout constants (in seconds)
+DEFAULT_TIMEOUT = 30
+
+# User investment profile location (same file backing ib://user/profile)
+PROFILE_PATH = Path("notes/investor-profile.yaml")
+
+# Staged-entry defaults
+DEFAULT_TRANCHES = 4
+# Cumulative discount from the entry anchor for tranches 1..4
+_TRANCHE_DISCOUNTS = [0.00, 0.03, 0.06, 0.10]
+# When the user should not "chase", first tranche waits for this pullback
+_NO_CHASE_PULLBACK = 0.03
+
+# Decision thresholds on the composite conviction score (~ -1.0 .. +1.0)
+_BUY_THRESHOLD = 0.20
+_AVOID_THRESHOLD = -0.15
+
+# Weighting of technical vs sentiment in the composite score
+_TECH_WEIGHT = 0.65
+_SENTIMENT_WEIGHT = 0.35
+
+
+# ---------------------------------------------------------------------------
+# Profile / data helpers
+# ---------------------------------------------------------------------------
+def _read_user_profile() -> dict[str, Any]:
+    """Read the user investment profile (notes/investor-profile.yaml).
+
+    Returns an empty dict if the file is missing or malformed so callers can
+    degrade gracefully.
+    """
+    if not PROFILE_PATH.exists():
+        return {}
+    try:
+        with open(PROFILE_PATH) as f:
+            data = yaml.safe_load(f)
+    except (yaml.YAMLError, OSError) as e:
+        logger.warning("Failed to read user profile: %s", e)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+async def _compute_technical_signals(symbol: str) -> dict[str, Any]:
+    """Compute technical analysis by reusing the technical_analysis helpers.
+
+    Fetches ~1y of daily history and runs the same support/resistance, trend,
+    indicator, volume and signal computations used by ``get_stock_analysis``.
+
+    Raises:
+        IBTimeoutError: If Yahoo Finance times out.
+        YahooFinanceError: If no history is available.
+    """
+    import yfinance as yf
+
+    def _load() -> Any:
+        return yf.Ticker(symbol).history(period="252d", interval="1d")
+
+    try:
+        hist = await asyncio.wait_for(asyncio.to_thread(_load), timeout=DEFAULT_TIMEOUT)
+    except TimeoutError as e:
+        raise IBTimeoutError(
+            f"Yahoo Finance API timed out after {DEFAULT_TIMEOUT} seconds",
+            operation="evaluate_position.technicals",
+        ) from e
+
+    if hist is None or hist.empty:
+        raise YahooFinanceError(f"No price history found for {symbol}")
+
+    close = hist["Close"]
+    support_resistance = _find_support_resistance(hist)
+    trend = _analyze_trends(close)
+    indicators = _calculate_indicators(hist)
+    volume = _analyze_volume(hist)
+    signals = _generate_signals(
+        float(close.iloc[-1]),
+        support_resistance,
+        trend,
+        indicators,
+        volume,
+    )
+    return {
+        "current_price": float(close.iloc[-1]),
+        "support_resistance": support_resistance,
+        "trend": trend,
+        "indicators": indicators,
+        "signals": signals,
+    }
+
+
+async def _fetch_stock_context(symbol: str) -> dict[str, Any]:
+    """Fetch valuation / info context via Yahoo Finance ``Ticker.info``.
+
+    Best-effort: returns ``{}`` on any failure so the decision can still be made
+    from technicals + sentiment.
+    """
+    import yfinance as yf
+
+    def _load() -> dict[str, Any]:
+        return yf.Ticker(symbol).info or {}
+
+    try:
+        info = await asyncio.wait_for(asyncio.to_thread(_load), timeout=DEFAULT_TIMEOUT)
+    except Exception as e:
+        logger.warning("Failed to fetch stock context for %s: %s", symbol, e)
+        return {}
+
+    price = info.get("currentPrice") or info.get("regularMarketPrice") or info.get("previousClose")
+    return {
+        "name": info.get("longName") or info.get("shortName"),
+        "quote_type": info.get("quoteType"),  # "EQUITY" | "ETF" | ...
+        "currency": info.get("currency"),
+        "sector": info.get("sector"),
+        "industry": info.get("industry"),
+        "current_price": float(price) if price is not None else None,
+        "trailing_pe": info.get("trailingPE"),
+        "forward_pe": info.get("forwardPE"),
+        "dividend_yield": info.get("dividendYield"),
+        "beta": info.get("beta"),
+        "fifty_two_week_high": info.get("fiftyTwoWeekHigh"),
+        "fifty_two_week_low": info.get("fiftyTwoWeekLow"),
+        "market_cap": info.get("marketCap"),
+    }
+
+
+async def _fetch_sentiment(symbol: str, lookback_days: int) -> SentimentScore | None:
+    """Fetch news sentiment, returning ``None`` on failure (best-effort)."""
+    analyzer = NewsSentimentAnalyzer(lookback_days=lookback_days)
+    try:
+        return await asyncio.wait_for(analyzer.analyze_sentiment(symbol), timeout=DEFAULT_TIMEOUT)
+    except Exception as e:
+        logger.warning("Failed to fetch sentiment for %s: %s", symbol, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Pure synthesis helpers
+# ---------------------------------------------------------------------------
+def _is_chasing(tech: dict[str, Any]) -> bool:
+    """Detect whether buying now would be "chasing a bounce".
+
+    True when price sits near resistance or RSI is overbought — situations the
+    user explicitly wants to avoid following.
+    """
+    sr = tech.get("support_resistance", {})
+    if sr.get("current_level") == "near_resistance":
+        return True
+    rsi = tech.get("indicators", {}).get("rsi", {})
+    return bool(rsi.get("signal") == "overbought")
+
+
+def _synthesize_recommendation(
+    tech: dict[str, Any],
+    sentiment: SentimentScore | None,
+) -> dict[str, Any]:
+    """Combine technical and sentiment signals into a Buy/Hold/Avoid decision.
+
+    Returns a dict with ``recommendation``, ``conviction`` (composite score),
+    ``technical_score``, ``sentiment_score`` and a ``rationale`` list.
+    """
+    signals = tech.get("signals", {})
+    technical_score = float(signals.get("score", 0.0))
+
+    sentiment_score = 0.0
+    if sentiment is not None:
+        # Confidence-weight the sentiment contribution.
+        sentiment_score = float(sentiment.score) * float(sentiment.confidence)
+
+    composite = round(_TECH_WEIGHT * technical_score + _SENTIMENT_WEIGHT * sentiment_score, 3)
+    chasing = _is_chasing(tech)
+
+    rationale: list[str] = []
+    # Surface the strongest technical signals.
+    rationale.extend(f"Technical: {sig}" for sig in signals.get("signals", [])[:4])
+    if sentiment is not None:
+        rationale.extend(f"Sentiment: {theme}" for theme in (sentiment.key_themes or [])[:2])
+
+    if composite >= _BUY_THRESHOLD and chasing:
+        recommendation = "Hold"
+        rationale.append(
+            "Signals are constructive but price is near resistance / overbought — "
+            "wait for a pullback rather than chasing the bounce."
+        )
+    elif composite >= _BUY_THRESHOLD:
+        recommendation = "Buy"
+        rationale.append(
+            f"Composite conviction {composite:+.2f} clears the buy threshold "
+            f"({_BUY_THRESHOLD:+.2f}); accumulate in staged tranches."
+        )
+    elif composite <= _AVOID_THRESHOLD:
+        recommendation = "Avoid"
+        rationale.append(
+            f"Composite conviction {composite:+.2f} is below the avoid threshold "
+            f"({_AVOID_THRESHOLD:+.2f}); no compelling entry."
+        )
+    else:
+        recommendation = "Hold"
+        rationale.append(
+            f"Composite conviction {composite:+.2f} is neutral; wait for a clearer "
+            "setup before committing capital."
+        )
+
+    return {
+        "recommendation": recommendation,
+        "conviction": composite,
+        "technical_score": round(technical_score, 3),
+        "sentiment_score": round(sentiment_score, 3),
+        "chasing_risk": chasing,
+        "rationale": rationale,
+    }
+
+
+def _build_staged_entry(
+    *,
+    current_price: float,
+    support_resistance: dict[str, Any],
+    candidate_size: float | None,
+    recommendation: str,
+    chasing_risk: bool,
+    tranches: int = DEFAULT_TRANCHES,
+) -> dict[str, Any]:
+    """Build a 3-4 tranche staged-entry plan.
+
+    Tranches step down from an anchor price toward nearest support. When the
+    user should not chase (``chasing_risk`` or a non-Buy recommendation), the
+    first tranche is set below market to wait for a pullback.
+    """
+    if recommendation == "Avoid":
+        return {
+            "applicable": False,
+            "reason": "Recommendation is Avoid — no entry plan generated.",
+            "tranches": [],
+        }
+
+    tranches = max(3, min(tranches, len(_TRANCHE_DISCOUNTS)))
+    discounts = _TRANCHE_DISCOUNTS[:tranches]
+
+    # Anchor: buy-at-market for a clean Buy, otherwise wait for a pullback.
+    wait_for_pullback = chasing_risk or recommendation != "Buy"
+    anchor = current_price * (1 - _NO_CHASE_PULLBACK) if wait_for_pullback else current_price
+
+    nearest_support = support_resistance.get("nearest_support")
+
+    per_tranche_size: float | None = None
+    if candidate_size is not None:
+        per_tranche_size = round(candidate_size / tranches, 2)
+    weight_pct = round(100.0 / tranches, 1)
+
+    plan: list[dict[str, Any]] = []
+    for i, discount in enumerate(discounts):
+        target = anchor * (1 - discount)
+        # Anchor the deepest tranche to support when support sits below it.
+        if i == len(discounts) - 1 and nearest_support is not None and nearest_support < target:
+            target = float(nearest_support)
+        plan.append(
+            {
+                "tranche": i + 1,
+                "price_band": {
+                    "low": round(target * 0.99, 2),
+                    "high": round(target * 1.01, 2),
+                },
+                "weight_pct": weight_pct,
+                "size": per_tranche_size,
+            }
+        )
+
+    return {
+        "applicable": True,
+        "strategy": "staged_entry",
+        "tranche_count": tranches,
+        "anchor_price": round(anchor, 2),
+        "waits_for_pullback": wait_for_pullback,
+        "note": (
+            "First tranche set below market to avoid chasing the bounce; scale in "
+            "on weakness toward support."
+            if wait_for_pullback
+            else "Scale in across tranches; add on dips toward support."
+        ),
+        "tranches": plan,
+    }
+
+
+def _build_tax_fx_notes(
+    *,
+    symbol: str,
+    stock_ctx: dict[str, Any],
+    profile: dict[str, Any],
+) -> dict[str, Any]:
+    """Build tax and FX guidance for a Malaysia-resident, IE-domicile preference.
+
+    - Flags Ireland-domiciled alternatives for US-listed ETFs.
+    - Notes US dividend-withholding considerations.
+    - Notes FX exposure when the security is not denominated in the base
+      currency.
+    """
+    residency = (profile.get("residency") or {}).get("country")
+    etf_prefs = profile.get("etf_preferences") or {}
+    preferred_domicile = etf_prefs.get("domicile", "IE")
+    base_currency = profile.get("base_currency") or "USD"
+
+    notes: list[str] = []
+    ie_alternative = ETF_ALTERNATIVES.get(symbol.upper())
+    quote_type = (stock_ctx.get("quote_type") or "").upper()
+    currency = stock_ctx.get("currency")
+    dividend_yield = stock_ctx.get("dividend_yield")
+
+    if ie_alternative:
+        notes.append(
+            f"{symbol} is US-domiciled. Prefer Ireland-domiciled {ie_alternative} "
+            f"(15% US dividend withholding at fund level vs 30% for a Malaysia "
+            f"resident holding US-domiciled funds) — matches your {preferred_domicile} "
+            "domicile preference."
+        )
+    elif quote_type == "ETF" and preferred_domicile == "IE":
+        notes.append(
+            f"{symbol} is an ETF with no mapped Ireland-domiciled alternative; "
+            "verify its domicile before buying to preserve withholding efficiency."
+        )
+
+    if dividend_yield and residency == "Malaysia" and not ie_alternative:
+        notes.append(
+            "Malaysia has no tax treaty reducing US dividend withholding; US-listed "
+            "dividend payers incur 30% withholding. Favour IE-domiciled or "
+            "low/no-dividend instruments."
+        )
+
+    if currency and currency != base_currency:
+        notes.append(
+            f"{symbol} trades in {currency} vs your {base_currency} base currency — "
+            f"the position carries {currency}/{base_currency} FX exposure."
+        )
+
+    return {
+        "residency": residency,
+        "preferred_domicile": preferred_domicile,
+        "base_currency": base_currency,
+        "ireland_alternative": ie_alternative,
+        "security_currency": currency,
+        "notes": notes,
+    }
+
+
+def _build_portfolio_fit(
+    *,
+    stock_ctx: dict[str, Any],
+    candidate_size: float | None,
+    profile: dict[str, Any],
+) -> dict[str, Any]:
+    """Assess fit against the user's target allocation and external holdings.
+
+    Lightweight, credential-free guidance: maps the candidate to an asset class
+    and compares the candidate size against external holdings for rough sizing.
+    Deep concentration/overlap checks against live IB positions are out of scope
+    for this tool (they require account data) and are tracked as follow-up.
+    """
+    quote_type = (stock_ctx.get("quote_type") or "").upper()
+    asset_class = "BOND" if quote_type in {"BOND"} else "STK"
+
+    allocation_targets = profile.get("allocation_targets") or {}
+    external = profile.get("external_holdings") or {}
+    total_value = external.get("total_value")
+
+    notes: list[str] = []
+    target_pct: float | None = None
+    if asset_class == "STK" and "stocks" in allocation_targets:
+        target_pct = float(allocation_targets["stocks"])
+    elif asset_class == "BOND" and "bonds" in allocation_targets:
+        target_pct = float(allocation_targets["bonds"])
+    if target_pct is not None:
+        notes.append(
+            f"Candidate maps to asset class {asset_class}; your target allocation "
+            f"for this class is {target_pct:.0f}%."
+        )
+
+    size_pct: float | None = None
+    if candidate_size is not None and total_value:
+        try:
+            size_pct = round(candidate_size / float(total_value) * 100, 2)
+            notes.append(
+                f"Candidate size {candidate_size:,.0f} is ~{size_pct:.2f}% of your "
+                f"~{float(total_value):,.0f} external holdings."
+            )
+        except (TypeError, ZeroDivisionError, ArithmeticError):
+            size_pct = None
+
+    notes.append(
+        "Live concentration/overlap against existing IB positions requires account "
+        "data and is not evaluated here."
+    )
+
+    return {
+        "asset_class": asset_class,
+        "target_allocation_pct": target_pct,
+        "candidate_size_pct_of_external": size_pct,
+        "notes": notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+def register_position_advisor_tools(mcp: FastMCP) -> None:
+    """Register the position advisor tool."""
+
+    @mcp.tool
+    async def evaluate_position(
+        symbol: str,
+        candidate_size: float | None = None,
+        account: int = 0,
+        lookback_days: int = 7,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Evaluate a candidate symbol and return a single integrated position decision.
+
+        Synthesizes technicals, news sentiment, valuation, tax/FX considerations,
+        a staged-entry plan and portfolio-fit guidance into one Buy/Hold/Avoid
+        recommendation with rationale — tailored to the user's investment profile
+        (Malaysia tax residency, Ireland-domiciled ETF preference, staged entry,
+        no chasing bounces).
+
+        Args:
+            symbol: Candidate ticker symbol (e.g., "CSPX", "VOO", "AAPL").
+            candidate_size: Optional intended position size (base-currency amount).
+                When provided, the staged-entry plan and portfolio-fit notes
+                include per-tranche sizing.
+            account: Account index for profile/portfolio context (default: 0).
+            lookback_days: News sentiment lookback window in days (default: 7).
+            ctx: MCP context for logging.
+
+        Returns:
+            JSON string with:
+            - ``recommendation``: "Buy" | "Hold" | "Avoid"
+            - ``conviction``: composite score (~ -1.0 .. +1.0)
+            - ``rationale``: list of reasons behind the decision
+            - ``technical``, ``sentiment``, ``valuation``: component summaries
+            - ``staged_entry``: tranche plan with price bands and sizing
+            - ``tax_fx``: withholding / Ireland-domicile / FX notes
+            - ``portfolio_fit``: target-allocation guidance
+
+        Raises:
+            ValidationError: If input validation fails.
+            YahooFinanceError: If no price data is available.
+            IBTimeoutError: If a data fetch times out.
+        """
+        try:
+            symbol = validate_symbol(symbol)
+            if candidate_size is not None and candidate_size <= 0:
+                raise ValidationError("candidate_size must be positive", field="candidate_size")
+            if lookback_days <= 0:
+                raise ValidationError("lookback_days must be positive", field="lookback_days")
+
+            if ctx:
+                await ctx.info(f"Evaluating position for {symbol}")
+
+            profile = _read_user_profile()
+
+            # Gather components concurrently. Technicals are required; sentiment
+            # and valuation are best-effort.
+            tech_res, stock_res, sentiment_res = await asyncio.gather(
+                _compute_technical_signals(symbol),
+                _fetch_stock_context(symbol),
+                _fetch_sentiment(symbol, lookback_days),
+                return_exceptions=True,
+            )
+
+            if isinstance(tech_res, BaseException):
+                if isinstance(tech_res, IBAnalyticsError):
+                    raise tech_res
+                raise YahooFinanceError(f"Could not evaluate technicals for {symbol}") from tech_res
+
+            tech: dict[str, Any] = tech_res
+            stock_ctx: dict[str, Any] = {} if isinstance(stock_res, BaseException) else stock_res
+            sentiment: SentimentScore | None = (
+                None if isinstance(sentiment_res, BaseException) else sentiment_res
+            )
+
+            current_price = tech.get("current_price") or stock_ctx.get("current_price")
+            if not current_price:
+                raise YahooFinanceError(f"No current price available for {symbol}")
+
+            decision = _synthesize_recommendation(tech, sentiment)
+            staged_entry = _build_staged_entry(
+                current_price=float(current_price),
+                support_resistance=tech.get("support_resistance", {}),
+                candidate_size=candidate_size,
+                recommendation=decision["recommendation"],
+                chasing_risk=decision["chasing_risk"],
+            )
+            tax_fx = _build_tax_fx_notes(symbol=symbol, stock_ctx=stock_ctx, profile=profile)
+            portfolio_fit = _build_portfolio_fit(
+                stock_ctx=stock_ctx, candidate_size=candidate_size, profile=profile
+            )
+
+            signals = tech.get("signals", {})
+            result: dict[str, Any] = {
+                "symbol": symbol,
+                "as_of": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "candidate_size": candidate_size,
+                "recommendation": decision["recommendation"],
+                "conviction": decision["conviction"],
+                "current_price": round(float(current_price), 2),
+                "rationale": decision["rationale"],
+                "technical": {
+                    "score": decision["technical_score"],
+                    "signal": signals.get("recommendation"),
+                    "signals": signals.get("signals", []),
+                    "current_level": tech.get("support_resistance", {}).get("current_level"),
+                    "nearest_support": tech.get("support_resistance", {}).get("nearest_support"),
+                    "nearest_resistance": tech.get("support_resistance", {}).get(
+                        "nearest_resistance"
+                    ),
+                    "rsi": tech.get("indicators", {}).get("rsi"),
+                    "trend": tech.get("trend", {}).get("trend_strength"),
+                },
+                "sentiment": (
+                    {
+                        "available": True,
+                        "score": float(sentiment.score),
+                        "confidence": float(sentiment.confidence),
+                        "key_themes": sentiment.key_themes,
+                        "risk_factors": sentiment.risk_factors,
+                    }
+                    if sentiment is not None
+                    else {"available": False}
+                ),
+                "valuation": {
+                    "name": stock_ctx.get("name"),
+                    "quote_type": stock_ctx.get("quote_type"),
+                    "sector": stock_ctx.get("sector"),
+                    "currency": stock_ctx.get("currency"),
+                    "trailing_pe": stock_ctx.get("trailing_pe"),
+                    "forward_pe": stock_ctx.get("forward_pe"),
+                    "dividend_yield": stock_ctx.get("dividend_yield"),
+                    "beta": stock_ctx.get("beta"),
+                    "fifty_two_week_high": stock_ctx.get("fifty_two_week_high"),
+                    "fifty_two_week_low": stock_ctx.get("fifty_two_week_low"),
+                },
+                "staged_entry": staged_entry,
+                "tax_fx": tax_fx,
+                "portfolio_fit": portfolio_fit,
+            }
+
+            if ctx:
+                await ctx.info(
+                    f"{symbol}: {decision['recommendation']} "
+                    f"(conviction {decision['conviction']:+.2f})"
+                )
+
+            return json.dumps(result, indent=2, default=str)
+
+        except IBAnalyticsError:
+            raise
+        except Exception as e:
+            if ctx:
+                await ctx.error(f"Unexpected error in evaluate_position: {e!s}")
+            raise ValidationError(f"evaluate_position failed for {symbol}") from e

--- a/tests/mcp/test_position_advisor.py
+++ b/tests/mcp/test_position_advisor.py
@@ -10,8 +10,9 @@ Ireland-domicile / FX tax notes, validation, and error masking.
 import json
 from datetime import datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
+import pandas as pd
 import pytest
 from fastmcp import FastMCP
 
@@ -392,6 +393,10 @@ class TestPureHelpers:
     def test_is_chasing_neutral(self) -> None:
         assert pa._is_chasing(make_tech()) is False
 
+    def test_is_chasing_handles_none_valued_keys(self) -> None:
+        # Keys present but explicitly None must not raise (gemini PR #149 feedback).
+        assert pa._is_chasing({"support_resistance": None, "indicators": None}) is False
+
     def test_staged_entry_avoid_not_applicable(self) -> None:
         plan = pa._build_staged_entry(
             current_price=100.0,
@@ -415,3 +420,31 @@ class TestPureHelpers:
         # Weights sum to ~100%.
         total_weight = sum(t["weight_pct"] for t in plan["tranches"])
         assert total_weight == pytest.approx(100.0, abs=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Technical-signal data guards
+# ---------------------------------------------------------------------------
+class TestComputeTechnicalSignals:
+    async def test_empty_history_raises(self) -> None:
+        with patch("yfinance.Ticker") as ticker:
+            ticker.return_value.history.return_value = pd.DataFrame()
+            with pytest.raises(YahooFinanceError, match="No price history"):
+                await pa._compute_technical_signals("AAPL")
+
+    async def test_insufficient_history_raises(self) -> None:
+        # Fewer than _MIN_HISTORY_POINTS rows -> guard trips before NaN math
+        # (gemini PR #149 feedback).
+        short = pd.DataFrame(
+            {
+                "Open": [1.0] * 5,
+                "High": [1.0] * 5,
+                "Low": [1.0] * 5,
+                "Close": [1.0] * 5,
+                "Volume": [100] * 5,
+            }
+        )
+        with patch("yfinance.Ticker") as ticker:
+            ticker.return_value.history.return_value = short
+            with pytest.raises(YahooFinanceError, match="Insufficient price history"):
+                await pa._compute_technical_signals("AAPL")

--- a/tests/mcp/test_position_advisor.py
+++ b/tests/mcp/test_position_advisor.py
@@ -1,0 +1,417 @@
+"""Tests for the ``evaluate_position`` position-advisor MCP tool.
+
+The tool composes several network-backed building blocks (technicals, news
+sentiment, Yahoo Finance info). Those are patched at the module's private
+helper boundary so the tests focus on the tool's own synthesis logic:
+Buy/Hold/Avoid decisioning, the chase-avoidance guard, staged-entry planning,
+Ireland-domicile / FX tax notes, validation, and error masking.
+"""
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+
+import ib_sec_mcp.mcp.tools.position_advisor as pa
+from ib_sec_mcp.analyzers.sentiment.base import SentimentScore
+from ib_sec_mcp.mcp.exceptions import ValidationError, YahooFinanceError
+from ib_sec_mcp.mcp.tools.position_advisor import register_position_advisor_tools
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+def make_tech(
+    *,
+    score: float = 0.5,
+    current_price: float = 100.0,
+    current_level: str = "neutral",
+    rsi_signal: str = "neutral",
+    nearest_support: float | None = 90.0,
+    nearest_resistance: float | None = 110.0,
+    signal_recommendation: str = "buy",
+) -> dict:
+    """Build a technical-signals dict matching ``_compute_technical_signals``."""
+    return {
+        "current_price": current_price,
+        "support_resistance": {
+            "current_level": current_level,
+            "nearest_support": nearest_support,
+            "nearest_resistance": nearest_resistance,
+            "support_levels": [nearest_support] if nearest_support else [],
+            "resistance_levels": [nearest_resistance] if nearest_resistance else [],
+        },
+        "trend": {"trend_strength": "strong", "short_term": "uptrend"},
+        "indicators": {
+            "rsi": {"value": 55.0, "signal": rsi_signal},
+            "macd": {"trend": "bullish", "histogram": 0.3},
+        },
+        "signals": {
+            "recommendation": signal_recommendation,
+            "score": score,
+            "signals": ["Strong uptrend across timeframes"],
+        },
+    }
+
+
+def make_stock_ctx(
+    *,
+    quote_type: str = "EQUITY",
+    currency: str = "USD",
+    dividend_yield: float | None = 0.015,
+    name: str = "Test Corp",
+) -> dict:
+    return {
+        "name": name,
+        "quote_type": quote_type,
+        "currency": currency,
+        "sector": "Technology",
+        "industry": "Software",
+        "current_price": 100.0,
+        "trailing_pe": 25.0,
+        "forward_pe": 22.0,
+        "dividend_yield": dividend_yield,
+        "beta": 1.1,
+        "fifty_two_week_high": 130.0,
+        "fifty_two_week_low": 80.0,
+        "market_cap": 1_000_000_000,
+    }
+
+
+def make_sentiment(score: str = "0.4", confidence: str = "0.8") -> SentimentScore:
+    return SentimentScore(
+        score=Decimal(score),
+        confidence=Decimal(confidence),
+        timestamp=datetime(2026, 1, 1, 12, 0, 0),
+        key_themes=["earnings beat"],
+        risk_factors=["macro headwinds"],
+        reasoning="test",
+    )
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    register_position_advisor_tools(mcp)
+    return mcp
+
+
+def patch_components(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tech: dict,
+    stock_ctx: dict | None = None,
+    sentiment: SentimentScore | None = None,
+    profile: dict | None = None,
+) -> None:
+    """Patch the private data-fetch helpers with deterministic results."""
+    monkeypatch.setattr(pa, "_compute_technical_signals", AsyncMock(return_value=tech))
+    monkeypatch.setattr(pa, "_fetch_stock_context", AsyncMock(return_value=stock_ctx or {}))
+    monkeypatch.setattr(pa, "_fetch_sentiment", AsyncMock(return_value=sentiment))
+    monkeypatch.setattr(pa, "_read_user_profile", lambda: profile or {})
+
+
+# ---------------------------------------------------------------------------
+# Decision logic
+# ---------------------------------------------------------------------------
+class TestRecommendation:
+    async def test_buy_when_signals_strong(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6, current_level="neutral"),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        data = json.loads(result)
+        assert data["symbol"] == "AAPL"
+        assert data["recommendation"] == "Buy"
+        assert data["conviction"] > pa._BUY_THRESHOLD
+        assert data["staged_entry"]["applicable"] is True
+        assert data["rationale"]
+        # All top-level sections present
+        for key in (
+            "technical",
+            "sentiment",
+            "valuation",
+            "staged_entry",
+            "tax_fx",
+            "portfolio_fit",
+            "current_price",
+        ):
+            assert key in data
+
+    async def test_avoid_when_signals_negative(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=-0.6, signal_recommendation="sell"),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("-0.5"),
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="XYZ", ctx=None)
+        data = json.loads(result)
+        assert data["recommendation"] == "Avoid"
+        assert data["conviction"] <= pa._AVOID_THRESHOLD
+        assert data["staged_entry"]["applicable"] is False
+        assert data["staged_entry"]["tranches"] == []
+
+    async def test_hold_when_neutral(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.0),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.0"),
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        data = json.loads(result)
+        assert data["recommendation"] == "Hold"
+
+    async def test_chase_guard_downgrades_buy_to_hold(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Strong score but price near resistance -> do not chase.
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.7, current_level="near_resistance"),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        data = json.loads(result)
+        assert data["recommendation"] == "Hold"
+        assert data["technical"]["current_level"] == "near_resistance"
+        assert data["staged_entry"]["waits_for_pullback"] is True
+        assert any("pullback" in r.lower() or "chas" in r.lower() for r in data["rationale"])
+
+    async def test_overbought_triggers_chase_guard(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.7, rsi_signal="overbought"),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        data = json.loads(result)
+        assert data["recommendation"] == "Hold"
+        assert data["staged_entry"]["waits_for_pullback"] is True
+
+
+# ---------------------------------------------------------------------------
+# Staged entry
+# ---------------------------------------------------------------------------
+class TestStagedEntry:
+    async def test_tranches_and_sizing(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+        )
+        result = await call_tool_fn(
+            test_mcp, "evaluate_position", symbol="AAPL", candidate_size=10000.0, ctx=None
+        )
+        data = json.loads(result)
+        staged = data["staged_entry"]
+        assert staged["tranche_count"] == pa.DEFAULT_TRANCHES
+        assert len(staged["tranches"]) == pa.DEFAULT_TRANCHES
+        # Equal split of candidate size across tranches.
+        sizes = [t["size"] for t in staged["tranches"]]
+        assert all(s == pytest.approx(10000.0 / pa.DEFAULT_TRANCHES) for s in sizes)
+        # Price bands step downward (accumulate on weakness).
+        highs = [t["price_band"]["high"] for t in staged["tranches"]]
+        assert highs == sorted(highs, reverse=True)
+
+    async def test_deepest_tranche_anchors_to_support(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6, current_price=100.0, nearest_support=85.0),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        data = json.loads(result)
+        last = data["staged_entry"]["tranches"][-1]
+        # Deepest band brackets the support level (85.0).
+        assert last["price_band"]["low"] <= 85.0 <= last["price_band"]["high"]
+
+
+# ---------------------------------------------------------------------------
+# Tax / FX
+# ---------------------------------------------------------------------------
+class TestTaxFx:
+    async def test_ireland_alternative_flagged_for_us_etf(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6),
+            stock_ctx=make_stock_ctx(quote_type="ETF"),
+            sentiment=make_sentiment("0.3"),
+            profile={
+                "residency": {"country": "Malaysia"},
+                "etf_preferences": {"domicile": "IE"},
+            },
+        )
+        # VOO is a US-listed ETF mapped to an Ireland-domiciled alternative.
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="VOO", ctx=None)
+        data = json.loads(result)
+        assert data["tax_fx"]["ireland_alternative"] == "VUAA.L"
+        assert any("Ireland-domiciled" in n for n in data["tax_fx"]["notes"])
+
+    async def test_fx_note_when_currency_differs(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.3),
+            stock_ctx=make_stock_ctx(currency="GBP"),
+            sentiment=make_sentiment("0.2"),
+            profile={"base_currency": "USD"},
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="IDTL", ctx=None)
+        data = json.loads(result)
+        assert data["tax_fx"]["security_currency"] == "GBP"
+        assert any("FX exposure" in n for n in data["tax_fx"]["notes"])
+
+    async def test_portfolio_fit_size_pct(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.3"),
+            profile={
+                "allocation_targets": {"stocks": 75, "bonds": 15, "cash": 10},
+                "external_holdings": {"total_value": 100000},
+            },
+        )
+        result = await call_tool_fn(
+            test_mcp, "evaluate_position", symbol="AAPL", candidate_size=10000.0, ctx=None
+        )
+        data = json.loads(result)
+        fit = data["portfolio_fit"]
+        assert fit["asset_class"] == "STK"
+        assert fit["target_allocation_pct"] == 75.0
+        assert fit["candidate_size_pct_of_external"] == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# Degradation and validation
+# ---------------------------------------------------------------------------
+class TestRobustness:
+    async def test_sentiment_unavailable_still_returns(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6),
+            stock_ctx=make_stock_ctx(),
+            sentiment=None,
+        )
+        result = await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        data = json.loads(result)
+        assert data["sentiment"]["available"] is False
+        assert data["recommendation"] in {"Buy", "Hold", "Avoid"}
+
+    async def test_invalid_candidate_size_raises(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(monkeypatch, tech=make_tech(), stock_ctx=make_stock_ctx())
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp, "evaluate_position", symbol="AAPL", candidate_size=-5.0, ctx=None
+            )
+
+    async def test_invalid_lookback_raises(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(monkeypatch, tech=make_tech(), stock_ctx=make_stock_ctx())
+        with pytest.raises(ValidationError):
+            await call_tool_fn(
+                test_mcp, "evaluate_position", symbol="AAPL", lookback_days=0, ctx=None
+            )
+
+    async def test_technical_failure_raises_yahoo_error(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            pa,
+            "_compute_technical_signals",
+            AsyncMock(side_effect=YahooFinanceError("No price history found for AAPL")),
+        )
+        monkeypatch.setattr(pa, "_fetch_stock_context", AsyncMock(return_value={}))
+        monkeypatch.setattr(pa, "_fetch_sentiment", AsyncMock(return_value=None))
+        monkeypatch.setattr(pa, "_read_user_profile", lambda: {})
+        with pytest.raises(YahooFinanceError):
+            await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+
+    async def test_generic_technical_failure_is_masked(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A non-IBAnalyticsError from the core technical fetch is wrapped, not leaked.
+        monkeypatch.setattr(
+            pa,
+            "_compute_technical_signals",
+            AsyncMock(side_effect=RuntimeError("internal boom")),
+        )
+        monkeypatch.setattr(pa, "_fetch_stock_context", AsyncMock(return_value={}))
+        monkeypatch.setattr(pa, "_fetch_sentiment", AsyncMock(return_value=None))
+        monkeypatch.setattr(pa, "_read_user_profile", lambda: {})
+        with pytest.raises(YahooFinanceError) as exc_info:
+            await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        assert "internal boom" not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+class TestPureHelpers:
+    def test_is_chasing_near_resistance(self) -> None:
+        assert pa._is_chasing(make_tech(current_level="near_resistance")) is True
+
+    def test_is_chasing_overbought(self) -> None:
+        assert pa._is_chasing(make_tech(rsi_signal="overbought")) is True
+
+    def test_is_chasing_neutral(self) -> None:
+        assert pa._is_chasing(make_tech()) is False
+
+    def test_staged_entry_avoid_not_applicable(self) -> None:
+        plan = pa._build_staged_entry(
+            current_price=100.0,
+            support_resistance={"nearest_support": 90.0},
+            candidate_size=None,
+            recommendation="Avoid",
+            chasing_risk=False,
+        )
+        assert plan["applicable"] is False
+
+    def test_staged_entry_buy_anchors_at_market(self) -> None:
+        plan = pa._build_staged_entry(
+            current_price=100.0,
+            support_resistance={"nearest_support": 90.0},
+            candidate_size=None,
+            recommendation="Buy",
+            chasing_risk=False,
+        )
+        assert plan["waits_for_pullback"] is False
+        assert plan["anchor_price"] == pytest.approx(100.0)
+        # Weights sum to ~100%.
+        total_weight = sum(t["weight_pct"] for t in plan["tranches"])
+        assert total_weight == pytest.approx(100.0, abs=0.5)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -101,6 +101,8 @@ EXPECTED_TOOLS = {
     "get_sync_status",
     # earnings_calendar
     "get_earnings_calendar",
+    # position_advisor
+    "evaluate_position",
 }
 
 # CP Gateway live-trading tools gated behind IB_ENABLE_LIVE_TRADING (default OFF).


### PR DESCRIPTION
## Summary

Resolves #128. Adds a **position-decision synthesis MCP tool** — `evaluate_position` — that evaluates a candidate symbol in a single call and returns an integrated **Buy / Hold / Avoid** recommendation with rationale, a staged-entry plan, tax/FX notes, and portfolio-fit guidance.

This is the core-value tool requested in the Wave-5 epic. It is **composition-only**: it orchestrates existing analyzers/helpers and adds explicit decision logic — no indicator math is re-implemented.

## What it composes

| Dimension | Source (reused) |
|-----------|-----------------|
| Technicals | `technical_analysis` helpers (`_find_support_resistance`, `_analyze_trends`, `_calculate_indicators`, `_analyze_volume`, `_generate_signals`) |
| Sentiment | `NewsSentimentAnalyzer` |
| Valuation / info | Yahoo Finance `Ticker.info` (sector, P/E, dividend yield, beta, 52w range) |
| Tax / FX | `ETF_ALTERNATIVES` (US→IE mapping), Malaysia withholding notes, FX exposure |
| Staged entry | Explicit 3–4 tranche logic honoring "don't chase bounces" |
| Portfolio fit | Target allocation from `ib://user/profile` (`notes/investor-profile.yaml`) |

## Profile-aware decision logic

- **Composite conviction** = 0.65·technical + 0.35·(sentiment·confidence) → Buy/Hold/Avoid thresholds.
- **Chase-avoidance guard**: a strong score near resistance / RSI-overbought is downgraded Buy→Hold and the first entry tranche waits for a pullback (matches the user's "don't chase bounces" rule).
- **Staged entry**: 3–4 tranches stepping down toward support; deepest tranche anchored to nearest support; per-tranche sizing when `candidate_size` is given.
- **IE-domicile preference**: US-listed ETFs surface their Ireland-domiciled alternative (e.g. `VOO`→`VUAA.L`) with a 15% vs 30% withholding note for a Malaysia resident.
- **Graceful degradation**: technicals are required; sentiment and valuation are best-effort. Internal errors are masked (no detail leaked to clients).

## Changes

- **New** `ib_sec_mcp/mcp/tools/position_advisor.py`
- **New** `tests/mcp/test_position_advisor.py` (20 tests, all dependencies mocked)
- Registered in `ib_sec_mcp/mcp/tools/__init__.py`
- Added `evaluate_position` to `EXPECTED_TOOLS` in `tests/mcp/test_server.py`

## Testing

- `uv run pytest tests/mcp/` → **481 passed** (incl. server smoke test validating the tool set)
- `uv run ruff check` / `uv run ruff format` → clean
- `uv run mypy ib_sec_mcp/mcp/tools/position_advisor.py` → clean
- New module coverage **75%** (uncovered lines are the network I/O wrappers, intentionally mocked; all decision logic is covered)

## Acceptance criteria

- [x] One tool call returns an integrated, rationale-backed decision for a candidate symbol — green.

## Notes / out of scope

- **Live concentration/overlap** against existing IB positions (deep `analyze_risk` integration) requires account credentials and is intentionally out of scope here; `portfolio_fit` provides credential-free target-allocation guidance and flags this limitation. Tracked as a follow-up.
- Tool-count figures in `CLAUDE.md` / `docs/` are deliberately left unchanged to avoid merge conflicts with other parallel Wave-5 issues that also add tools; recommend a single docs-sync pass after the wave merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)