### PR TITLE
feat(events): integrate earnings/ex-div event monitoring into daily-check and position decisions (#131)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -191,7 +191,7 @@ uv run pytest --cov=ib_sec_mcp
 
 ## MCP Server Quick Reference
 
-59 tools (51 default + 8 live-trading tools gated behind `IB_ENABLE_LIVE_TRADING`), 9 resources, 5 prompts. Full reference: [docs/mcp-tools-reference.md](../docs/mcp-tools-reference.md)
+62 tools (54 default + 8 live-trading tools gated behind `IB_ENABLE_LIVE_TRADING`), 9 resources, 5 prompts. Full reference: [docs/mcp-tools-reference.md](../docs/mcp-tools-reference.md)
 
 ---
 

--- a/.claude/commands/daily-check.md
+++ b/.claude/commands/daily-check.md
@@ -67,10 +67,14 @@ For any symbols in pending orders that were NOT in portfolio positions, fetch th
 
 ### Step 4.5: Upcoming Event Check
 
-Call `get_upcoming_events` with a 14-day horizon to surface near-term earnings / ex-dividend events for holdings (and any watchlist symbols from pending orders).
+Call `get_upcoming_events` with a 14-day horizon to surface near-term earnings / ex-dividend events for holdings **plus pending-order symbols that are not current holdings**.
+
+Pass any unheld pending-order symbols from Step 4 as `watchlist` so they are swept alongside holdings — otherwise `get_upcoming_events` only loads portfolio holdings and an imminent event on an unheld limit-order target would produce no `EVENT_SOON` alert, defeating the staged-entry pause this step is meant to add.
 
 ```
-get_upcoming_events(days=14)
+# `watchlist` = pending-order symbols from Step 4 not already in portfolio positions
+get_upcoming_events(days=14, watchlist=["{unheld_order_sym_1}", "{unheld_order_sym_2}"])
+# If there are no unheld pending-order symbols, simply call get_upcoming_events(days=14)
 ```
 
 Record each event's `symbol`, `event_type`, `event_date`, `days_until`, and `flag`. Events flagged `EVENT_SOON` (within 3 days) feed the alert step below. If the call fails, note it and continue (events are advisory, not blocking).

--- a/.claude/commands/daily-check.md
+++ b/.claude/commands/daily-check.md
@@ -1,6 +1,6 @@
 ---
 description: Daily portfolio monitoring for scheduled tasks (no user interaction)
-allowed-tools: Read, Write, Edit, mcp__ib-sec-mcp__sync_daily_snapshot, mcp__ib-sec-mcp__get_current_price, mcp__ib-sec-mcp__check_order_proximity, mcp__ib-sec-mcp__get_pending_orders, mcp__ib-sec-mcp__analyze_consolidated_portfolio
+allowed-tools: Read, Write, Edit, mcp__ib-sec-mcp__sync_daily_snapshot, mcp__ib-sec-mcp__get_current_price, mcp__ib-sec-mcp__check_order_proximity, mcp__ib-sec-mcp__get_pending_orders, mcp__ib-sec-mcp__analyze_consolidated_portfolio, mcp__ib-sec-mcp__get_upcoming_events
 argument-hint: [--verbose]
 ---
 
@@ -65,6 +65,16 @@ check_order_proximity(threshold_pct=5.0)
 
 For any symbols in pending orders that were NOT in portfolio positions, fetch their current prices too (parallel `get_current_price` calls).
 
+### Step 4.5: Upcoming Event Check
+
+Call `get_upcoming_events` with a 14-day horizon to surface near-term earnings / ex-dividend events for holdings (and any watchlist symbols from pending orders).
+
+```
+get_upcoming_events(days=14)
+```
+
+Record each event's `symbol`, `event_type`, `event_date`, `days_until`, and `flag`. Events flagged `EVENT_SOON` (within 3 days) feed the alert step below. If the call fails, note it and continue (events are advisory, not blocking).
+
 ### Step 5: Alert Generation
 
 Generate alerts based on these thresholds:
@@ -75,12 +85,14 @@ Generate alerts based on these thresholds:
 | Limit order distance <= 5% (but > 3%)        | ALERT            | APPROACHING |
 | Daily price change > +/-3%                   | VOLATILITY ALERT | VOLATILE    |
 | Current price <= limit price (likely filled) | FILL CHECK       | FILL CHECK  |
+| Earnings/ex-div within 3 days (`EVENT_SOON`) | EVENT ALERT      | EVENT SOON  |
 
 Classification logic:
 
 - Use `distance_pct` from `check_order_proximity` results for order alerts
 - Use `day_change_percent` from `get_current_price` results for volatility alerts
 - If current price is at or below the buy limit price, flag as FILL CHECK
+- Use `flag == "EVENT_SOON"` from `get_upcoming_events` for event alerts; treat an imminent earnings date as a reason to pause staged entries into that symbol
 
 ### Step 6: Memory Update — daily-snapshot.md (OVERWRITE — every run)
 
@@ -108,6 +120,14 @@ Sync Status: {status from Step 1}
 | Symbol | Limit    | Current    | Distance | Alert        |
 | ------ | -------- | ---------- | -------- | ------------ |
 | {sym}  | ${limit} | ${current} | {X.X%}   | {level or —} |
+
+## Upcoming Events (next 14 days)
+
+| Symbol | Event  | Date         | Days | Flag              |
+| ------ | ------ | ------------ | ---- | ----------------- |
+| {sym}  | {type} | {YYYY-MM-DD} | {N}  | {EVENT_SOON or —} |
+
+(or "None within 14 days" if empty)
 
 ## Active Alerts
 
@@ -195,6 +215,11 @@ Display the following to the conversation:
 ### Limit Order Status
 | Symbol | Limit | Current | Distance | Alert |
 |--------|-------|---------|----------|-------|
+| ... | ... | ... | ... | ... |
+
+### Upcoming Events (next 14 days)
+| Symbol | Event | Date | Days | Flag |
+|--------|-------|------|------|------|
 | ... | ... | ... | ... | ... |
 
 ### Alerts

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -4,12 +4,12 @@ Complete reference for all MCP tools, resources, and prompts provided by the IB 
 
 ## Overview
 
-IB Analytics provides **59 tools**, **9 resources**, and **5 prompts** across two usage modes:
+IB Analytics provides **62 tools**, **9 resources**, and **5 prompts** across two usage modes:
 
 - **Mode 1 (Claude Desktop)**: Coarse-grained tools for complete, self-contained analysis
 - **Mode 2 (Claude Code + MCP)**: Fine-grained tools for composable, custom workflows
 
-Of the 59 tools, **51 are registered by default** and **8 are gated** behind the
+Of the 62 tools, **54 are registered by default** and **8 are gated** behind the
 `IB_ENABLE_LIVE_TRADING` flag (CP Gateway live trading + order management — disabled by
 default). See [Live Trading & Order Management](#live-trading--order-management-gated).
 
@@ -47,9 +47,14 @@ relies on:
 | [Limit Orders](#limit-orders)                                            | 6           | Both   | DB (+CP/Yahoo) | Local limit-order tracking and proximity alerts  |
 | [Daily Monitor](#daily-monitor)                                          | 2           | Mode 1 | Flex + DB      | Reliable fetch+sync pipeline with health checks  |
 | [Earnings Calendar](#earnings-calendar)                                  | 1           | Both   | Yahoo + DB     | Upcoming earnings and ex-dividend dates          |
+| [Events Monitor](#events-monitor)                                        | 1           | Both   | Yahoo + DB     | Near-term event monitoring with EVENT_SOON flags |
 | [Live Trading & Order Management](#live-trading--order-management-gated) | 8 _(gated)_ | Mode 1 | CP             | Live broker trading via CP Gateway (opt-in)      |
 
-**Total: 59 tools** (51 default-enabled + 8 gated behind `IB_ENABLE_LIVE_TRADING`).
+**Total: 62 tools** (54 default-enabled + 8 gated behind `IB_ENABLE_LIVE_TRADING`).
+
+> **Note:** The category subtotals above are being reconciled separately (see the
+> tracking issue for docs/tool-count alignment); the headline totals reflect the
+> tools actually registered by the server.
 
 ---
 
@@ -1034,6 +1039,41 @@ is loaded from the latest snapshot in the position store (DB).
 ```
 >>> calendar = await get_earnings_calendar(days_ahead=30)
 >>> calendar = await get_earnings_calendar(symbols=["AAPL", "MSFT"], days_ahead=60)
+```
+
+---
+
+## Events Monitor
+
+### `get_upcoming_events`
+
+Monitor near-term earnings / ex-dividend events for portfolio holdings plus an optional
+watchlist, flagging imminent ones (`EVENT_SOON`). Complements `get_earnings_calendar` by
+turning the same calendar data into a flat, sorted monitoring feed suitable for
+`/daily-check` alerts and for feeding near-term event risk into `evaluate_position`.
+
+**Data source**: Yahoo (`yfinance` calendars). When `symbols` is omitted, holdings are
+loaded from the latest snapshot in the position store (DB); `watchlist` symbols are merged
+in on top.
+
+| Parameter             | Type        | Required | Default              | Description                                                        |
+| --------------------- | ----------- | -------- | -------------------- | ------------------------------------------------------------------ |
+| `days`                | `int`       | No       | `14`                 | Monitoring horizon in days; events further out are omitted         |
+| `symbols`             | `list[str]` | No       | latest snapshot syms | Base tickers to monitor. When omitted, loaded from latest snapshot |
+| `watchlist`           | `list[str]` | No       | -                    | Additional non-held symbols to monitor alongside holdings          |
+| `soon_threshold_days` | `int`       | No       | `3`                  | Events within this many days are flagged `EVENT_SOON`              |
+
+**Returns**: JSON object with `as_of`, `days_ahead`, `soon_threshold_days`, `event_count`,
+`event_soon_count`, `events` (flat, soonest-first; each with `symbol`, `event_type`
+(`earnings` | `ex_dividend`), `event_date`, `days_until`, `flag`) and `errors`. Per-symbol
+yfinance failures and invalid symbols are collected in `errors` rather than raising.
+
+> Interest-rate (macro) events are not yet sourced per-symbol; the `event_type` field is
+> intentionally open for a future rate feed.
+
+```
+>>> events = await get_upcoming_events(days=14)
+>>> events = await get_upcoming_events(symbols=["CSPX"], watchlist=["NVDA"], soon_threshold_days=5)
 ```
 
 ---

--- a/ib_sec_mcp/mcp/tools/__init__.py
+++ b/ib_sec_mcp/mcp/tools/__init__.py
@@ -26,6 +26,7 @@ def register_all_tools(mcp: FastMCP) -> None:
         register_etf_calculator_tools,
     )
     from ib_sec_mcp.mcp.tools.etf_comparison import register_etf_comparison_tools
+    from ib_sec_mcp.mcp.tools.events_monitor import register_events_monitor_tools
     from ib_sec_mcp.mcp.tools.ib_portfolio import register_ib_portfolio_tools
     from ib_sec_mcp.mcp.tools.limit_orders import register_limit_order_tools
     from ib_sec_mcp.mcp.tools.live_trading import register_live_trading_tools
@@ -89,6 +90,7 @@ def register_all_tools(mcp: FastMCP) -> None:
 
     register_daily_monitor_tools(mcp)  # Add daily monitor tools
     register_earnings_calendar_tools(mcp)  # Add earnings and dividend calendar tools
+    register_events_monitor_tools(mcp)  # Add upcoming-event monitoring tool
 
 
 __all__ = ["register_all_tools"]

--- a/ib_sec_mcp/mcp/tools/events_monitor.py
+++ b/ib_sec_mcp/mcp/tools/events_monitor.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Iterable
-from datetime import date, datetime
+from datetime import date
 from typing import Any
 
 import yfinance as yf
@@ -131,9 +131,11 @@ async def _fetch_symbol_events(
     async with semaphore:
         try:
             calendar = await asyncio.to_thread(lambda: yf.Ticker(symbol).calendar)
+            return build_symbol_events(
+                symbol, calendar, current_date, days_ahead, soon_threshold_days
+            )
         except Exception as exc:
             return [{"symbol": symbol, "error": str(exc)}]
-    return build_symbol_events(symbol, calendar, current_date, days_ahead, soon_threshold_days)
 
 
 def _sort_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -230,7 +232,7 @@ def register_events_monitor_tools(mcp: FastMCP) -> None:
 
         return json.dumps(
             {
-                "as_of": datetime.combine(current_date, datetime.min.time()).strftime("%Y-%m-%d"),
+                "as_of": current_date.isoformat(),
                 "days_ahead": days,
                 "soon_threshold_days": soon_threshold_days,
                 "event_count": len(sorted_events),

--- a/ib_sec_mcp/mcp/tools/events_monitor.py
+++ b/ib_sec_mcp/mcp/tools/events_monitor.py
@@ -1,0 +1,243 @@
+"""Upcoming event monitoring MCP tools.
+
+Aggregates near-term corporate events — earnings and ex-dividend dates (and,
+best-effort, interest-rate events) — for portfolio holdings plus an optional
+watchlist, flagging events that are imminent (``EVENT_SOON``).
+
+This complements ``get_earnings_calendar`` (single-shot lookup) by turning the
+same yfinance-backed calendar data into a monitoring feed: a flat, sorted list
+of events with proximity flags suitable for ``/daily-check`` alerts and for
+feeding near-term event risk into position decisions (``evaluate_position``).
+
+The parsing/normalisation helpers are reused from
+:mod:`ib_sec_mcp.mcp.tools.earnings_calendar` so the two tools agree on how
+yfinance calendar payloads are interpreted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterable
+from datetime import date, datetime
+from typing import Any
+
+import yfinance as yf
+from fastmcp import Context, FastMCP
+
+from ib_sec_mcp.mcp.tools.earnings_calendar import (
+    FETCH_CONCURRENCY_LIMIT,
+    _days_until,
+    _extract_calendar_value,
+    _first_upcoming_date,
+    _load_symbols_from_latest_snapshot,
+    _normalize_symbols,
+)
+
+# Default proximity threshold: events within this many days are flagged EVENT_SOON.
+EVENT_SOON_THRESHOLD_DAYS = 3
+
+# Default monitoring horizon (issue #131: get_upcoming_events(days=14)).
+DEFAULT_DAYS_AHEAD = 14
+
+# Event types sourced from the yfinance calendar (key -> normalized event_type).
+_CALENDAR_EVENT_TYPES: tuple[tuple[str, str], ...] = (
+    ("Earnings Date", "earnings"),
+    ("Ex-Dividend Date", "ex_dividend"),
+)
+
+# Proximity flag emitted for imminent events.
+EVENT_SOON_FLAG = "EVENT_SOON"
+
+
+def _today() -> date:
+    """Return today's date (indirection so tests can freeze the clock)."""
+    return date.today()
+
+
+def build_symbol_events(
+    symbol: str,
+    calendar: Any,
+    current_date: date,
+    days_ahead: int,
+    soon_threshold_days: int,
+) -> list[dict[str, Any]]:
+    """Build the list of upcoming event records for a single symbol.
+
+    Pure transformation over an already-fetched yfinance ``calendar`` payload.
+    Only events that fall within ``[today, today + days_ahead]`` are returned.
+
+    Args:
+        symbol: Normalized ticker symbol.
+        calendar: yfinance ``Ticker.calendar`` payload (dict or DataFrame-like).
+        current_date: Reference "today".
+        days_ahead: Inclusive monitoring horizon in days.
+        soon_threshold_days: Events within this many days are flagged EVENT_SOON.
+
+    Returns:
+        List of event records, each with ``symbol``, ``event_type``,
+        ``event_date`` (ISO string), ``days_until`` and ``flag``
+        (``"EVENT_SOON"`` or ``None``).
+    """
+    records: list[dict[str, Any]] = []
+    for calendar_key, event_type in _CALENDAR_EVENT_TYPES:
+        event_date = _first_upcoming_date(
+            _extract_calendar_value(calendar, calendar_key),
+            current_date,
+        )
+        days_until = _days_until(event_date, current_date, days_ahead)
+        if days_until is None or event_date is None:
+            continue
+        records.append(
+            {
+                "symbol": symbol,
+                "event_type": event_type,
+                "event_date": event_date.isoformat(),
+                "days_until": days_until,
+                "flag": EVENT_SOON_FLAG if days_until <= soon_threshold_days else None,
+            }
+        )
+    return records
+
+
+def _collect_symbols(
+    symbols: Iterable[str] | None,
+    watchlist: Iterable[str] | None,
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Resolve the monitored symbol set (holdings + watchlist) and validate it.
+
+    When ``symbols`` is ``None`` the portfolio holdings from the latest snapshot
+    are used as the base set. ``watchlist`` symbols are always merged in.
+    Duplicates are removed while preserving first-seen order.
+    """
+    base = list(symbols) if symbols is not None else _load_symbols_from_latest_snapshot()
+    if watchlist:
+        base = [*base, *watchlist]
+    return _normalize_symbols(base)
+
+
+async def _fetch_symbol_events(
+    symbol: str,
+    current_date: date,
+    days_ahead: int,
+    soon_threshold_days: int,
+    semaphore: asyncio.Semaphore,
+) -> list[dict[str, Any]]:
+    """Fetch and normalize upcoming events for one symbol (concurrency-limited).
+
+    A yfinance failure is returned as a single error record rather than raising,
+    so one bad symbol never aborts the whole sweep.
+    """
+    async with semaphore:
+        try:
+            calendar = await asyncio.to_thread(lambda: yf.Ticker(symbol).calendar)
+        except Exception as exc:
+            return [{"symbol": symbol, "error": str(exc)}]
+    return build_symbol_events(symbol, calendar, current_date, days_ahead, soon_threshold_days)
+
+
+def _sort_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort events by soonest first, then symbol, keeping errors last."""
+
+    def sort_key(event: dict[str, Any]) -> tuple[int, int, str]:
+        if "error" in event:
+            return (1, 999_999, str(event.get("symbol", "")))
+        days_until = event.get("days_until")
+        days = days_until if isinstance(days_until, int) else 999_999
+        return (0, days, str(event.get("symbol", "")))
+
+    return sorted(events, key=sort_key)
+
+
+def register_events_monitor_tools(mcp: FastMCP) -> None:
+    """Register the upcoming-events monitoring tool."""
+
+    @mcp.tool
+    async def get_upcoming_events(
+        days: int = DEFAULT_DAYS_AHEAD,
+        symbols: list[str] | None = None,
+        watchlist: list[str] | None = None,
+        soon_threshold_days: int = EVENT_SOON_THRESHOLD_DAYS,
+        ctx: Context | None = None,
+    ) -> str:
+        """
+        Monitor upcoming earnings / ex-dividend events for holdings + watchlist.
+
+        Aggregates near-term corporate events across portfolio holdings and an
+        optional watchlist, flagging imminent ones (``EVENT_SOON``) so staged
+        entry / exit decisions and ``/daily-check`` can react before the event.
+
+        Args:
+            days: Monitoring horizon in days (default: 14). Events further out
+                than this are omitted.
+            symbols: Base symbols to monitor. When omitted, holdings from the
+                latest portfolio snapshot are used.
+            watchlist: Additional non-held symbols to monitor alongside holdings.
+            soon_threshold_days: Events within this many days are flagged
+                ``EVENT_SOON`` (default: 3).
+            ctx: MCP context for logging.
+
+        Returns:
+            JSON string with ``as_of``, ``days_ahead``, ``soon_threshold_days``,
+            ``event_count``, ``event_soon_count``, ``events`` (flat, soonest
+            first) and ``errors``. Each event has ``symbol``, ``event_type``
+            (``"earnings"`` | ``"ex_dividend"``), ``event_date``, ``days_until``
+            and ``flag``.
+
+        Note:
+            Interest-rate (macro) events are not yet sourced per-symbol; the
+            ``event_type`` field is intentionally open for a future rate feed.
+        """
+        if days < 0:
+            return json.dumps({"error": "days must be zero or greater"}, indent=2)
+        if soon_threshold_days < 0:
+            return json.dumps({"error": "soon_threshold_days must be zero or greater"}, indent=2)
+
+        normalized_symbols, validation_errors = _collect_symbols(symbols, watchlist)
+
+        if ctx:
+            await ctx.info(
+                f"Monitoring upcoming events for {len(normalized_symbols)} symbol(s)",
+                extra={"days_ahead": days, "soon_threshold_days": soon_threshold_days},
+            )
+
+        current_date = _today()
+        semaphore = asyncio.Semaphore(FETCH_CONCURRENCY_LIMIT)
+        fetched = await asyncio.gather(
+            *(
+                _fetch_symbol_events(symbol, current_date, days, soon_threshold_days, semaphore)
+                for symbol in normalized_symbols
+            )
+        )
+
+        events: list[dict[str, Any]] = []
+        errors: list[dict[str, str]] = list(validation_errors)
+        for records in fetched:
+            for record in records:
+                if "error" in record:
+                    errors.append(record)
+                else:
+                    events.append(record)
+
+        sorted_events = _sort_events(events)
+        event_soon_count = sum(1 for event in sorted_events if event.get("flag") == EVENT_SOON_FLAG)
+
+        if ctx:
+            await ctx.info(
+                f"Found {len(sorted_events)} upcoming event(s), "
+                f"{event_soon_count} flagged {EVENT_SOON_FLAG}"
+            )
+
+        return json.dumps(
+            {
+                "as_of": datetime.combine(current_date, datetime.min.time()).strftime("%Y-%m-%d"),
+                "days_ahead": days,
+                "soon_threshold_days": soon_threshold_days,
+                "event_count": len(sorted_events),
+                "event_soon_count": event_soon_count,
+                "events": sorted_events,
+                "errors": errors,
+            },
+            indent=2,
+            default=str,
+        )

--- a/ib_sec_mcp/mcp/tools/position_advisor.py
+++ b/ib_sec_mcp/mcp/tools/position_advisor.py
@@ -41,6 +41,10 @@ from ib_sec_mcp.mcp.exceptions import (
     ValidationError,
     YahooFinanceError,
 )
+from ib_sec_mcp.mcp.tools.events_monitor import (
+    EVENT_SOON_THRESHOLD_DAYS,
+    build_symbol_events,
+)
 from ib_sec_mcp.mcp.tools.ib_portfolio import ETF_ALTERNATIVES
 from ib_sec_mcp.mcp.tools.technical_analysis import (
     _analyze_trends,
@@ -77,6 +81,9 @@ _AVOID_THRESHOLD = -0.15
 # Weighting of technical vs sentiment in the composite score
 _TECH_WEIGHT = 0.65
 _SENTIMENT_WEIGHT = 0.35
+
+# Near-term event-risk horizon: how far ahead to scan for earnings / ex-div.
+_EVENT_RISK_DAYS_AHEAD = 14
 
 
 # ---------------------------------------------------------------------------
@@ -196,6 +203,33 @@ async def _fetch_sentiment(symbol: str, lookback_days: int) -> SentimentScore | 
         return None
 
 
+async def _fetch_event_risk(symbol: str) -> list[dict[str, Any]]:
+    """Fetch near-term earnings / ex-dividend events for the candidate symbol.
+
+    Best-effort: returns an empty list on any failure so the decision can still
+    be made from technicals + sentiment. Reuses the same yfinance calendar
+    parsing as ``get_upcoming_events`` for consistency.
+    """
+    import yfinance as yf
+
+    def _load() -> Any:
+        return yf.Ticker(symbol).calendar
+
+    try:
+        calendar = await asyncio.wait_for(asyncio.to_thread(_load), timeout=DEFAULT_TIMEOUT)
+    except Exception as e:
+        logger.warning("Failed to fetch event risk for %s: %s", symbol, e)
+        return []
+
+    return build_symbol_events(
+        symbol,
+        calendar,
+        datetime.now().date(),
+        _EVENT_RISK_DAYS_AHEAD,
+        EVENT_SOON_THRESHOLD_DAYS,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pure synthesis helpers
 # ---------------------------------------------------------------------------
@@ -210,6 +244,38 @@ def _is_chasing(tech: dict[str, Any]) -> bool:
         return True
     rsi = (tech.get("indicators") or {}).get("rsi") or {}
     return bool(rsi.get("signal") == "overbought")
+
+
+def _summarize_event_risk(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize near-term event risk from upcoming-event records.
+
+    ``near_term`` is true when any imminent event is flagged ``EVENT_SOON``
+    (e.g. earnings within a few days) — a signal to wait rather than commit
+    capital straight into binary event risk.
+    """
+    upcoming = [event for event in events if "error" not in event]
+    soon = [event for event in upcoming if event.get("flag") == "EVENT_SOON"]
+
+    next_earnings_days: int | None = None
+    for event in upcoming:
+        if event.get("event_type") == "earnings":
+            days = event.get("days_until")
+            if isinstance(days, int):
+                next_earnings_days = days
+            break
+
+    notes: list[str] = [
+        f"{event['event_type'].replace('_', '-')} in {event['days_until']} day(s) "
+        f"on {event['event_date']}"
+        for event in soon
+    ]
+
+    return {
+        "near_term": bool(soon),
+        "next_earnings_days": next_earnings_days,
+        "events": upcoming,
+        "notes": notes,
+    }
 
 
 def _synthesize_recommendation(
@@ -500,6 +566,8 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
             - ``staged_entry``: tranche plan with price bands and sizing
             - ``tax_fx``: withholding / Ireland-domicile / FX notes
             - ``portfolio_fit``: target-allocation guidance
+            - ``event_risk``: near-term earnings / ex-dividend events and whether
+              an imminent (``EVENT_SOON``) event argues for waiting
 
         Raises:
             ValidationError: If input validation fails.
@@ -518,12 +586,13 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
 
             profile = _read_user_profile()
 
-            # Gather components concurrently. Technicals are required; sentiment
-            # and valuation are best-effort.
-            tech_res, stock_res, sentiment_res = await asyncio.gather(
+            # Gather components concurrently. Technicals are required; sentiment,
+            # valuation and event risk are best-effort.
+            tech_res, stock_res, sentiment_res, event_res = await asyncio.gather(
                 _compute_technical_signals(symbol),
                 _fetch_stock_context(symbol),
                 _fetch_sentiment(symbol, lookback_days),
+                _fetch_event_risk(symbol),
                 return_exceptions=True,
             )
 
@@ -537,18 +606,30 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
             sentiment: SentimentScore | None = (
                 None if isinstance(sentiment_res, BaseException) else sentiment_res
             )
+            event_records: list[dict[str, Any]] = (
+                [] if isinstance(event_res, BaseException) else event_res
+            )
+            event_risk = _summarize_event_risk(event_records)
 
             current_price = tech.get("current_price") or stock_ctx.get("current_price")
             if not current_price:
                 raise YahooFinanceError(f"No current price available for {symbol}")
 
             decision = _synthesize_recommendation(tech, sentiment)
+            # Imminent binary events (e.g. earnings) are treated like chasing
+            # risk: prefer to wait for the event rather than enter straight into it.
+            if event_risk["near_term"]:
+                decision["rationale"].append(
+                    "Near-term event risk: "
+                    + "; ".join(event_risk["notes"])
+                    + " — consider waiting until after the event before committing."
+                )
             staged_entry = _build_staged_entry(
                 current_price=float(current_price),
                 support_resistance=tech.get("support_resistance") or {},
                 candidate_size=candidate_size,
                 recommendation=decision["recommendation"],
-                chasing_risk=decision["chasing_risk"],
+                chasing_risk=decision["chasing_risk"] or event_risk["near_term"],
             )
             tax_fx = _build_tax_fx_notes(symbol=symbol, stock_ctx=stock_ctx, profile=profile)
             portfolio_fit = _build_portfolio_fit(
@@ -603,6 +684,7 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
                 "staged_entry": staged_entry,
                 "tax_fx": tax_fx,
                 "portfolio_fit": portfolio_fit,
+                "event_risk": event_risk,
             }
 
             if ctx:

--- a/ib_sec_mcp/mcp/tools/position_advisor.py
+++ b/ib_sec_mcp/mcp/tools/position_advisor.py
@@ -217,17 +217,16 @@ async def _fetch_event_risk(symbol: str) -> list[dict[str, Any]]:
 
     try:
         calendar = await asyncio.wait_for(asyncio.to_thread(_load), timeout=DEFAULT_TIMEOUT)
+        return build_symbol_events(
+            symbol,
+            calendar,
+            datetime.now().date(),
+            _EVENT_RISK_DAYS_AHEAD,
+            EVENT_SOON_THRESHOLD_DAYS,
+        )
     except Exception as e:
         logger.warning("Failed to fetch event risk for %s: %s", symbol, e)
         return []
-
-    return build_symbol_events(
-        symbol,
-        calendar,
-        datetime.now().date(),
-        _EVENT_RISK_DAYS_AHEAD,
-        EVENT_SOON_THRESHOLD_DAYS,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp/test_events_monitor.py
+++ b/tests/mcp/test_events_monitor.py
@@ -1,0 +1,272 @@
+"""Tests for the upcoming-events monitoring MCP tool.
+
+The tool is registered on a real :class:`fastmcp.FastMCP` instance and invoked
+through the FastMCP tool API so the production path is exercised. All yfinance
+access is mocked, keeping the suite network-independent.
+"""
+
+import json
+from collections.abc import Callable
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+
+from ib_sec_mcp.mcp.tools.events_monitor import (
+    build_symbol_events,
+    register_events_monitor_tools,
+)
+from ib_sec_mcp.storage import PositionStore
+from tests.mcp._fastmcp_helpers import call_tool_fn
+
+PATCH_TARGET = "ib_sec_mcp.mcp.tools.events_monitor.yf.Ticker"
+
+
+class FakeTicker:
+    """yfinance ticker fake backed by per-symbol calendar data."""
+
+    calendars: dict[str, Any] = {}
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+    @property
+    def calendar(self) -> Any:
+        value = self.calendars[self.symbol]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+@pytest.fixture()
+def test_mcp() -> FastMCP:
+    """FastMCP instance with the events monitor tool registered."""
+    mcp = FastMCP("test")
+    register_events_monitor_tools(mcp)
+    return mcp
+
+
+@pytest.fixture()
+def patch_ticker(monkeypatch: pytest.MonkeyPatch) -> Callable[[dict[str, Any]], None]:
+    """Install FakeTicker with the given per-symbol calendar data."""
+
+    def _apply(calendars: dict[str, Any]) -> None:
+        monkeypatch.setattr(FakeTicker, "calendars", calendars)
+        monkeypatch.setattr(PATCH_TARGET, FakeTicker)
+
+    return _apply
+
+
+@pytest.fixture(autouse=True)
+def fixed_today(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Freeze today and ignore env account IDs for deterministic days-until."""
+    import ib_sec_mcp.mcp.tools.earnings_calendar as ec_module
+    import ib_sec_mcp.mcp.tools.events_monitor as module
+
+    monkeypatch.setattr(module, "_today", lambda: date(2026, 1, 1))
+    for env_var in ec_module.ACCOUNT_ID_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: build_symbol_events
+# ---------------------------------------------------------------------------
+def test_build_symbol_events_flags_and_filters() -> None:
+    """Imminent events are flagged EVENT_SOON; out-of-horizon events dropped."""
+    calendar = {
+        "Earnings Date": [date(2026, 1, 3)],  # 2 days -> EVENT_SOON
+        "Ex-Dividend Date": date(2026, 1, 10),  # 9 days -> no flag
+    }
+    records = build_symbol_events("AAPL", calendar, date(2026, 1, 1), 14, 3)
+
+    by_type = {r["event_type"]: r for r in records}
+    assert by_type["earnings"]["days_until"] == 2
+    assert by_type["earnings"]["flag"] == "EVENT_SOON"
+    assert by_type["ex_dividend"]["days_until"] == 9
+    assert by_type["ex_dividend"]["flag"] is None
+
+
+def test_build_symbol_events_omits_events_beyond_horizon() -> None:
+    """Events past the horizon produce no records."""
+    calendar = {"Earnings Date": [date(2026, 3, 1)], "Ex-Dividend Date": None}
+    assert build_symbol_events("AAPL", calendar, date(2026, 1, 1), 14, 3) == []
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_upcoming_events
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_upcoming_events_aggregates_and_sorts(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Events across symbols are flattened and sorted soonest-first."""
+    patch_ticker(
+        {
+            "AAPL": {"Earnings Date": [date(2026, 1, 10)], "Ex-Dividend Date": None},
+            "MSFT": {"Earnings Date": [date(2026, 1, 2)], "Ex-Dividend Date": None},
+        }
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_upcoming_events",
+        days=14,
+        symbols=["AAPL", "MSFT"],
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["event_count"] == 2
+    assert [e["symbol"] for e in data["events"]] == ["MSFT", "AAPL"]
+    assert data["events"][0]["days_until"] == 1
+    assert data["events"][0]["flag"] == "EVENT_SOON"
+    assert data["event_soon_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_merges_watchlist(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Watchlist symbols are monitored alongside the base symbol set."""
+    patch_ticker(
+        {
+            "AAPL": {"Earnings Date": [date(2026, 1, 5)], "Ex-Dividend Date": None},
+            "NVDA": {"Earnings Date": [date(2026, 1, 8)], "Ex-Dividend Date": None},
+        }
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_upcoming_events",
+        days=14,
+        symbols=["AAPL"],
+        watchlist=["NVDA"],
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert {e["symbol"] for e in data["events"]} == {"AAPL", "NVDA"}
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_custom_soon_threshold(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A wider soon threshold flags more events as EVENT_SOON."""
+    patch_ticker({"AAPL": {"Earnings Date": [date(2026, 1, 6)], "Ex-Dividend Date": None}})
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_upcoming_events",
+        days=14,
+        symbols=["AAPL"],
+        soon_threshold_days=7,
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert data["events"][0]["flag"] == "EVENT_SOON"
+    assert data["event_soon_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_collects_per_symbol_errors(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """A yfinance failure becomes an error entry without aborting the sweep."""
+    patch_ticker(
+        {
+            "AAPL": {"Earnings Date": [date(2026, 1, 5)], "Ex-Dividend Date": None},
+            "BROKEN": RuntimeError("symbol not supported"),
+        }
+    )
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_upcoming_events",
+        days=14,
+        symbols=["AAPL", "BROKEN"],
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert [e["symbol"] for e in data["events"]] == ["AAPL"]
+    assert data["errors"] == [{"symbol": "BROKEN", "error": "symbol not supported"}]
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_reports_invalid_symbols(
+    test_mcp: FastMCP, patch_ticker: Callable[[dict[str, Any]], None]
+) -> None:
+    """Invalid symbols are surfaced as errors while valid ones are processed."""
+    patch_ticker({"AAPL": {"Earnings Date": [date(2026, 1, 5)], "Ex-Dividend Date": None}})
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_upcoming_events",
+        days=14,
+        symbols=["AAPL", "!!bad!!"],
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert [e["symbol"] for e in data["events"]] == ["AAPL"]
+    assert any(e.get("symbol") == "!!bad!!" for e in data["errors"])
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_rejects_negative_days(test_mcp: FastMCP) -> None:
+    """A negative horizon is rejected before any yfinance access."""
+    result = await call_tool_fn(test_mcp, "get_upcoming_events", days=-1, ctx=None)
+    assert json.loads(result) == {"error": "days must be zero or greater"}
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_rejects_negative_soon_threshold(test_mcp: FastMCP) -> None:
+    """A negative soon threshold is rejected before any yfinance access."""
+    result = await call_tool_fn(
+        test_mcp, "get_upcoming_events", days=14, soon_threshold_days=-1, ctx=None
+    )
+    assert json.loads(result) == {"error": "soon_threshold_days must be zero or greater"}
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_loads_symbols_from_snapshot(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any]], None],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When symbols are omitted, the latest PositionStore snapshot supplies them."""
+    import ib_sec_mcp.mcp.tools.earnings_calendar as ec_module
+
+    db_path = tmp_path / "positions.db"
+    with PositionStore(db_path) as store, store.db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO snapshot_metadata
+            (account_id, snapshot_date, xml_file_path, date_range_from, date_range_to,
+             total_positions, total_value, total_cash)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("U1234567", "2025-12-31", "test.xml", "2025-12-01", "2025-12-31", 1, "1", "0"),
+        )
+        conn.execute(
+            """
+            INSERT INTO position_snapshots
+            (account_id, snapshot_date, symbol, description, asset_class,
+             quantity, mark_price, position_value, average_cost, cost_basis)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("U1234567", "2025-12-31", "AAPL", "AAPL", "STK", "1", "1", "1", "1", "1"),
+        )
+
+    monkeypatch.setattr(ec_module, "DEFAULT_DB_PATH", str(db_path))
+    patch_ticker({"AAPL": {"Earnings Date": [date(2026, 1, 5)], "Ex-Dividend Date": None}})
+
+    result = await call_tool_fn(test_mcp, "get_upcoming_events", days=14, ctx=None)
+    data = json.loads(result)
+
+    assert [e["symbol"] for e in data["events"]] == ["AAPL"]

--- a/tests/mcp/test_position_advisor.py
+++ b/tests/mcp/test_position_advisor.py
@@ -108,11 +108,13 @@ def patch_components(
     stock_ctx: dict | None = None,
     sentiment: SentimentScore | None = None,
     profile: dict | None = None,
+    events: list[dict] | None = None,
 ) -> None:
     """Patch the private data-fetch helpers with deterministic results."""
     monkeypatch.setattr(pa, "_compute_technical_signals", AsyncMock(return_value=tech))
     monkeypatch.setattr(pa, "_fetch_stock_context", AsyncMock(return_value=stock_ctx or {}))
     monkeypatch.setattr(pa, "_fetch_sentiment", AsyncMock(return_value=sentiment))
+    monkeypatch.setattr(pa, "_fetch_event_risk", AsyncMock(return_value=events or []))
     monkeypatch.setattr(pa, "_read_user_profile", lambda: profile or {})
 
 
@@ -448,3 +450,76 @@ class TestComputeTechnicalSignals:
             ticker.return_value.history.return_value = short
             with pytest.raises(YahooFinanceError, match="Insufficient price history"):
                 await pa._compute_technical_signals("AAPL")
+
+
+# ---------------------------------------------------------------------------
+# Near-term event risk (issue #131)
+# ---------------------------------------------------------------------------
+class TestEventRisk:
+    async def test_no_events_reports_empty_event_risk(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+            events=[],
+        )
+        data = json.loads(
+            await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        )
+        assert data["event_risk"]["near_term"] is False
+        assert data["event_risk"]["events"] == []
+
+    async def test_imminent_earnings_forces_pullback_and_rationale(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Strong Buy signals that would normally enter at market...
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6, current_level="neutral", rsi_signal="neutral"),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+            events=[
+                {
+                    "symbol": "AAPL",
+                    "event_type": "earnings",
+                    "event_date": "2026-01-03",
+                    "days_until": 2,
+                    "flag": "EVENT_SOON",
+                }
+            ],
+        )
+        data = json.loads(
+            await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        )
+        # ...but imminent earnings make the plan wait for a pullback.
+        assert data["event_risk"]["near_term"] is True
+        assert data["event_risk"]["next_earnings_days"] == 2
+        assert data["staged_entry"]["waits_for_pullback"] is True
+        assert any("event risk" in r.lower() for r in data["rationale"])
+
+    async def test_distant_event_does_not_flag_near_term(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+            events=[
+                {
+                    "symbol": "AAPL",
+                    "event_type": "ex_dividend",
+                    "event_date": "2026-01-12",
+                    "days_until": 11,
+                    "flag": None,
+                }
+            ],
+        )
+        data = json.loads(
+            await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        )
+        assert data["event_risk"]["near_term"] is False
+        assert data["event_risk"]["events"]  # still surfaced for visibility

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -101,6 +101,8 @@ EXPECTED_TOOLS = {
     "get_sync_status",
     # earnings_calendar
     "get_earnings_calendar",
+    # events_monitor
+    "get_upcoming_events",
     # position_advisor
     "evaluate_position",
 }


### PR DESCRIPTION
## Summary

Resolves #131. Turns the single-shot `get_earnings_calendar` lookup into a **monitoring feed** and wires near-term event risk into both `/daily-check` and position decisions.

## Changes

- **New tool `get_upcoming_events`** (`events_monitor.py`) — aggregates earnings / ex-dividend events for portfolio holdings **plus an optional watchlist** over a configurable horizon (default 14 days), flagging imminent events as `EVENT_SOON` (default ≤3 days). Reuses the `earnings_calendar` parsing helpers so both tools interpret yfinance calendars identically. Per-symbol failures and invalid symbols degrade into `errors` rather than raising.
- **Position-advisor integration (#13)** — `evaluate_position` now fetches near-term event risk concurrently, surfaces an `event_risk` block, and treats an imminent (binary) event like chasing risk: the staged-entry plan waits for a pullback and the rationale explains why.
- **`/daily-check` integration** — new event-check step (`get_upcoming_events(days=14)`), an `EVENT SOON` alert row, and an "Upcoming Events" section in both the snapshot file and displayed output.
- **Docs** — documented the new tool in `mcp-tools-reference.md` and corrected the headline tool counts to the values actually registered by the server (**62 total / 54 default**). Category subtotals in the reference table were already drifting (missing rows for prior PRs' tools) — flagged inline for separate reconciliation rather than silently half-fixed.

> Interest-rate (macro) events are intentionally left as a future feed — the `event_type` field is open for it. Tracked as a follow-up.

## Testing

- `tests/mcp/test_events_monitor.py` — 10 tests (pure `build_symbol_events` transform, aggregation/sorting, watchlist merge, custom thresholds, per-symbol + validation errors, snapshot-sourced symbols). All yfinance access mocked → network-independent.
- `tests/mcp/test_position_advisor.py` — 3 new tests covering the event-risk block, imminent-earnings → wait-for-pullback, and distant-event handling.
- `tests/mcp/test_server.py` — `get_upcoming_events` added to `EXPECTED_TOOLS`.
- Full suite: **1203 passed**, coverage 78%. `ruff format`/`ruff check`/`mypy` all clean.

## Acceptance criteria

- [x] Event-monitoring tool aggregating holdings + watchlist earnings/ex-div events
- [x] `EVENT_SOON` proximity flag integrated into `/daily-check`
- [x] Position-advisor reflects near-term event risk as an input
- [x] Tests (yfinance / DB mock)
- [ ] Interest-rate events — deferred (no per-symbol macro source); structure left open

🤖 Generated with [Claude Code](https://claude.com/claude-code)