### PR TITLE
feat(events): add interest-rate (macro) event feed to get_upcoming_events

### DIFF
--- a/.claude/commands/daily-check.md
+++ b/.claude/commands/daily-check.md
@@ -67,7 +67,7 @@ For any symbols in pending orders that were NOT in portfolio positions, fetch th
 
 ### Step 4.5: Upcoming Event Check
 
-Call `get_upcoming_events` with a 14-day horizon to surface near-term earnings / ex-dividend events for holdings **plus pending-order symbols that are not current holdings**.
+Call `get_upcoming_events` with a 14-day horizon to surface near-term earnings / ex-dividend events for holdings **plus pending-order symbols that are not current holdings**, together with global macro interest-rate (e.g. FOMC) decisions.
 
 Pass any unheld pending-order symbols from Step 4 as `watchlist` so they are swept alongside holdings — otherwise `get_upcoming_events` only loads portfolio holdings and an imminent event on an unheld limit-order target would produce no `EVENT_SOON` alert, defeating the staged-entry pause this step is meant to add.
 
@@ -77,26 +77,26 @@ get_upcoming_events(days=14, watchlist=["{unheld_order_sym_1}", "{unheld_order_s
 # If there are no unheld pending-order symbols, simply call get_upcoming_events(days=14)
 ```
 
-Record each event's `symbol`, `event_type`, `event_date`, `days_until`, and `flag`. Events flagged `EVENT_SOON` (within 3 days) feed the alert step below. If the call fails, note it and continue (events are advisory, not blocking).
+Record each event's `symbol`, `event_type`, `event_date`, `days_until`, and `flag`. Macro rate events are global and carry `symbol: null` (plus `central_bank` / `region` / `currency`); they apply to the whole portfolio. Events flagged `EVENT_SOON` (within 3 days) feed the alert step below. If the call fails, note it and continue (events are advisory, not blocking).
 
 ### Step 5: Alert Generation
 
 Generate alerts based on these thresholds:
 
-| Condition                                    | Alert Level      | Label       |
-| -------------------------------------------- | ---------------- | ----------- |
-| Limit order distance <= 3%                   | URGENT ALERT     | URGENT      |
-| Limit order distance <= 5% (but > 3%)        | ALERT            | APPROACHING |
-| Daily price change > +/-3%                   | VOLATILITY ALERT | VOLATILE    |
-| Current price <= limit price (likely filled) | FILL CHECK       | FILL CHECK  |
-| Earnings/ex-div within 3 days (`EVENT_SOON`) | EVENT ALERT      | EVENT SOON  |
+| Condition                                         | Alert Level      | Label       |
+| ------------------------------------------------- | ---------------- | ----------- |
+| Limit order distance <= 3%                        | URGENT ALERT     | URGENT      |
+| Limit order distance <= 5% (but > 3%)             | ALERT            | APPROACHING |
+| Daily price change > +/-3%                        | VOLATILITY ALERT | VOLATILE    |
+| Current price <= limit price (likely filled)      | FILL CHECK       | FILL CHECK  |
+| Earnings/ex-div/rate within 3 days (`EVENT_SOON`) | EVENT ALERT      | EVENT SOON  |
 
 Classification logic:
 
 - Use `distance_pct` from `check_order_proximity` results for order alerts
 - Use `day_change_percent` from `get_current_price` results for volatility alerts
 - If current price is at or below the buy limit price, flag as FILL CHECK
-- Use `flag == "EVENT_SOON"` from `get_upcoming_events` for event alerts; treat an imminent earnings date as a reason to pause staged entries into that symbol
+- Use `flag == "EVENT_SOON"` from `get_upcoming_events` for event alerts; treat an imminent earnings date as a reason to pause staged entries into that symbol, and an imminent macro rate decision (`event_type == "rate"`) as a reason to pause staged entries across the portfolio
 
 ### Step 6: Memory Update — daily-snapshot.md (OVERWRITE — every run)
 

--- a/ib_sec_mcp/mcp/tools/events_monitor.py
+++ b/ib_sec_mcp/mcp/tools/events_monitor.py
@@ -1,8 +1,13 @@
 """Upcoming event monitoring MCP tools.
 
-Aggregates near-term corporate events — earnings and ex-dividend dates (and,
-best-effort, interest-rate events) — for portfolio holdings plus an optional
-watchlist, flagging events that are imminent (``EVENT_SOON``).
+Aggregates near-term events for portfolio holdings plus an optional watchlist,
+flagging events that are imminent (``EVENT_SOON``). Two sources are combined:
+
+* per-symbol **earnings** and **ex-dividend** dates from yfinance calendars, and
+* **macro interest-rate** decisions (e.g. FOMC) from a curated, offline
+  calendar (:mod:`ib_sec_mcp.mcp.tools.rate_calendar`). Rate events are global
+  — emitted once with ``symbol: None`` — because a rate decision moves all risk
+  assets, not just same-currency holdings.
 
 This complements ``get_earnings_calendar`` (single-shot lookup) by turning the
 same yfinance-backed calendar data into a monitoring feed: a flat, sorted list
@@ -33,6 +38,7 @@ from ib_sec_mcp.mcp.tools.earnings_calendar import (
     _load_symbols_from_latest_snapshot,
     _normalize_symbols,
 )
+from ib_sec_mcp.mcp.tools.rate_calendar import build_rate_events
 
 # Default proximity threshold: events within this many days are flagged EVENT_SOON.
 EVENT_SOON_THRESHOLD_DAYS = 3
@@ -160,14 +166,17 @@ def register_events_monitor_tools(mcp: FastMCP) -> None:
         symbols: list[str] | None = None,
         watchlist: list[str] | None = None,
         soon_threshold_days: int = EVENT_SOON_THRESHOLD_DAYS,
+        include_rate_events: bool = True,
         ctx: Context | None = None,
     ) -> str:
         """
-        Monitor upcoming earnings / ex-dividend events for holdings + watchlist.
+        Monitor upcoming earnings / ex-dividend / rate events for holdings.
 
-        Aggregates near-term corporate events across portfolio holdings and an
-        optional watchlist, flagging imminent ones (``EVENT_SOON``) so staged
-        entry / exit decisions and ``/daily-check`` can react before the event.
+        Aggregates near-term events across portfolio holdings and an optional
+        watchlist, flagging imminent ones (``EVENT_SOON``) so staged entry /
+        exit decisions and ``/daily-check`` can react before the event. Combines
+        per-symbol earnings / ex-dividend dates with global macro interest-rate
+        (e.g. FOMC) decisions.
 
         Args:
             days: Monitoring horizon in days (default: 14). Events further out
@@ -177,18 +186,19 @@ def register_events_monitor_tools(mcp: FastMCP) -> None:
             watchlist: Additional non-held symbols to monitor alongside holdings.
             soon_threshold_days: Events within this many days are flagged
                 ``EVENT_SOON`` (default: 3).
+            include_rate_events: Include global macro interest-rate decisions
+                (default: True). Rate events apply to all symbols and so are
+                emitted once with ``symbol: null``.
             ctx: MCP context for logging.
 
         Returns:
             JSON string with ``as_of``, ``days_ahead``, ``soon_threshold_days``,
             ``event_count``, ``event_soon_count``, ``events`` (flat, soonest
-            first) and ``errors``. Each event has ``symbol``, ``event_type``
-            (``"earnings"`` | ``"ex_dividend"``), ``event_date``, ``days_until``
-            and ``flag``.
-
-        Note:
-            Interest-rate (macro) events are not yet sourced per-symbol; the
-            ``event_type`` field is intentionally open for a future rate feed.
+            first) and ``errors``. Each event has ``symbol`` (``null`` for
+            global rate events), ``event_type`` (``"earnings"`` |
+            ``"ex_dividend"`` | ``"rate"``), ``event_date``, ``days_until`` and
+            ``flag``. Rate events additionally carry ``central_bank``,
+            ``region``, ``currency`` and ``description``.
         """
         if days < 0:
             return json.dumps({"error": "days must be zero or greater"}, indent=2)
@@ -220,6 +230,11 @@ def register_events_monitor_tools(mcp: FastMCP) -> None:
                     errors.append(record)
                 else:
                     events.append(record)
+
+        # Global macro rate events (e.g. FOMC) apply to all symbols, so they are
+        # appended once rather than per held symbol.
+        if include_rate_events:
+            events.extend(build_rate_events(current_date, days, soon_threshold_days))
 
         sorted_events = _sort_events(events)
         event_soon_count = sum(1 for event in sorted_events if event.get("flag") == EVENT_SOON_FLAG)

--- a/ib_sec_mcp/mcp/tools/position_advisor.py
+++ b/ib_sec_mcp/mcp/tools/position_advisor.py
@@ -265,10 +265,12 @@ def _format_event_note(event: dict[str, Any]) -> str:
     """
     days = event.get("days_until")
     when = event.get("event_date")
-    if event.get("event_type") == "rate":
+    event_type = event.get("event_type")
+    if event_type == "rate":
         label = event.get("description") or f"{event.get('central_bank', 'Rate')} rate decision"
         return f"{label} in {days} day(s) on {when}"
-    return f"{event['event_type'].replace('_', '-')} in {days} day(s) on {when}"
+    label = event_type.replace("_", "-") if event_type else "event"
+    return f"{label} in {days} day(s) on {when}"
 
 
 def _summarize_event_risk(events: list[dict[str, Any]]) -> dict[str, Any]:
@@ -278,7 +280,13 @@ def _summarize_event_risk(events: list[dict[str, Any]]) -> dict[str, Any]:
     (e.g. earnings or an FOMC decision within a few days) — a signal to wait
     rather than commit capital straight into binary event risk.
     """
-    upcoming = [event for event in events if "error" not in event]
+    # Sort soonest-first so the combined per-symbol + global rate events are
+    # chronological (matching get_upcoming_events), which also makes
+    # next_earnings_days resolve to the *nearest* earnings.
+    upcoming = sorted(
+        (event for event in events if "error" not in event),
+        key=lambda event: event.get("days_until", 999_999),
+    )
     soon = [event for event in upcoming if event.get("flag") == "EVENT_SOON"]
 
     next_earnings_days: int | None = None

--- a/ib_sec_mcp/mcp/tools/position_advisor.py
+++ b/ib_sec_mcp/mcp/tools/position_advisor.py
@@ -46,6 +46,7 @@ from ib_sec_mcp.mcp.tools.events_monitor import (
     build_symbol_events,
 )
 from ib_sec_mcp.mcp.tools.ib_portfolio import ETF_ALTERNATIVES
+from ib_sec_mcp.mcp.tools.rate_calendar import build_rate_events
 from ib_sec_mcp.mcp.tools.technical_analysis import (
     _analyze_trends,
     _analyze_volume,
@@ -204,29 +205,40 @@ async def _fetch_sentiment(symbol: str, lookback_days: int) -> SentimentScore | 
 
 
 async def _fetch_event_risk(symbol: str) -> list[dict[str, Any]]:
-    """Fetch near-term earnings / ex-dividend events for the candidate symbol.
+    """Fetch near-term event risk for the candidate symbol.
 
-    Best-effort: returns an empty list on any failure so the decision can still
-    be made from technicals + sentiment. Reuses the same yfinance calendar
-    parsing as ``get_upcoming_events`` for consistency.
+    Combines per-symbol earnings / ex-dividend events (yfinance) with global
+    macro interest-rate decisions (e.g. FOMC), so the decision accounts for an
+    imminent rate event even when the symbol itself has no corporate event.
+
+    Best-effort: the per-symbol fetch returns nothing on any failure so the
+    decision can still be made from technicals + sentiment. Rate events are
+    offline/curated and always included. Reuses the same calendar parsing as
+    ``get_upcoming_events`` for consistency.
     """
     import yfinance as yf
+
+    current_date = datetime.now().date()
+    # Curated, offline — applies to all symbols, so always included.
+    rate_events = build_rate_events(current_date, _EVENT_RISK_DAYS_AHEAD, EVENT_SOON_THRESHOLD_DAYS)
 
     def _load() -> Any:
         return yf.Ticker(symbol).calendar
 
     try:
         calendar = await asyncio.wait_for(asyncio.to_thread(_load), timeout=DEFAULT_TIMEOUT)
-        return build_symbol_events(
+        symbol_events = build_symbol_events(
             symbol,
             calendar,
-            datetime.now().date(),
+            current_date,
             _EVENT_RISK_DAYS_AHEAD,
             EVENT_SOON_THRESHOLD_DAYS,
         )
     except Exception as e:
         logger.warning("Failed to fetch event risk for %s: %s", symbol, e)
-        return []
+        symbol_events = []
+
+    return [*symbol_events, *rate_events]
 
 
 # ---------------------------------------------------------------------------
@@ -245,12 +257,26 @@ def _is_chasing(tech: dict[str, Any]) -> bool:
     return bool(rsi.get("signal") == "overbought")
 
 
+def _format_event_note(event: dict[str, Any]) -> str:
+    """Render a human-readable note for an imminent event.
+
+    Rate (macro) events use their ``description`` / ``central_bank`` label;
+    corporate events fall back to a normalized ``event_type`` label.
+    """
+    days = event.get("days_until")
+    when = event.get("event_date")
+    if event.get("event_type") == "rate":
+        label = event.get("description") or f"{event.get('central_bank', 'Rate')} rate decision"
+        return f"{label} in {days} day(s) on {when}"
+    return f"{event['event_type'].replace('_', '-')} in {days} day(s) on {when}"
+
+
 def _summarize_event_risk(events: list[dict[str, Any]]) -> dict[str, Any]:
     """Summarize near-term event risk from upcoming-event records.
 
     ``near_term`` is true when any imminent event is flagged ``EVENT_SOON``
-    (e.g. earnings within a few days) — a signal to wait rather than commit
-    capital straight into binary event risk.
+    (e.g. earnings or an FOMC decision within a few days) — a signal to wait
+    rather than commit capital straight into binary event risk.
     """
     upcoming = [event for event in events if "error" not in event]
     soon = [event for event in upcoming if event.get("flag") == "EVENT_SOON"]
@@ -263,11 +289,7 @@ def _summarize_event_risk(events: list[dict[str, Any]]) -> dict[str, Any]:
                 next_earnings_days = days
             break
 
-    notes: list[str] = [
-        f"{event['event_type'].replace('_', '-')} in {event['days_until']} day(s) "
-        f"on {event['event_date']}"
-        for event in soon
-    ]
+    notes: list[str] = [_format_event_note(event) for event in soon]
 
     return {
         "near_term": bool(soon),
@@ -565,8 +587,9 @@ def register_position_advisor_tools(mcp: FastMCP) -> None:
             - ``staged_entry``: tranche plan with price bands and sizing
             - ``tax_fx``: withholding / Ireland-domicile / FX notes
             - ``portfolio_fit``: target-allocation guidance
-            - ``event_risk``: near-term earnings / ex-dividend events and whether
-              an imminent (``EVENT_SOON``) event argues for waiting
+            - ``event_risk``: near-term earnings / ex-dividend / macro rate
+              (e.g. FOMC) events and whether an imminent (``EVENT_SOON``) event
+              argues for waiting
 
         Raises:
             ValidationError: If input validation fails.

--- a/ib_sec_mcp/mcp/tools/rate_calendar.py
+++ b/ib_sec_mcp/mcp/tools/rate_calendar.py
@@ -1,0 +1,155 @@
+"""Curated macro interest-rate event calendar (issue #152).
+
+yfinance exposes per-symbol corporate calendars (earnings, ex-dividend) but has
+no macro feed for central-bank rate decisions. Those decision dates are,
+however, published a year or more in advance, so a small **curated, offline
+calendar** is the reliable and deterministic data source — no network call, no
+flaky third-party endpoint, and trivially testable.
+
+Design decisions (issue #152):
+
+* **Global, not per-symbol.** A rate decision moves all risk assets, not just
+  same-currency holdings, so each event is emitted **once** with ``symbol:
+  None`` rather than duplicated against every monitored ticker. Consumers that
+  want to filter by currency / asset class can do so using the
+  ``central_bank`` / ``region`` / ``currency`` metadata carried on each record.
+* **Same record shape as corporate events.** Records mirror
+  :func:`ib_sec_mcp.mcp.tools.events_monitor.build_symbol_events` output
+  (``event_type``, ``event_date``, ``days_until``, ``flag``) so they merge
+  cleanly into ``get_upcoming_events`` and ``evaluate_position`` event risk.
+
+Only the FOMC is curated today; the :class:`RateEvent` structure and
+:data:`RATE_EVENTS` tuple are intentionally open so other central banks (ECB,
+BoE, BoJ) can be appended without touching the builder.
+
+To refresh: replace the dates from the Fed's published schedule at
+https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm — use the
+**second (announcement) day** of each two-day meeting, when the rate decision
+is released.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, NamedTuple
+
+# event_type emitted for macro rate-decision events.
+RATE_EVENT_TYPE = "rate"
+
+# Proximity flag for imminent events. Mirrors
+# ``events_monitor.EVENT_SOON_FLAG``; duplicated here (rather than imported) to
+# keep this module a dependency-free leaf and avoid an import cycle, since
+# ``events_monitor`` imports *from* this module.
+EVENT_SOON_FLAG = "EVENT_SOON"
+
+
+class RateEvent(NamedTuple):
+    """A single scheduled central-bank rate decision.
+
+    Attributes:
+        event_date: Announcement (decision) date — the second day of an FOMC
+            meeting.
+        central_bank: Short issuer label, e.g. ``"FOMC"``.
+        region: Geographic region, e.g. ``"US"``.
+        currency: ISO currency code primarily affected, e.g. ``"USD"``.
+        description: Human-readable event label for notes / alerts.
+    """
+
+    event_date: date
+    central_bank: str
+    region: str
+    currency: str
+    description: str
+
+
+def _fomc(event_date: date) -> RateEvent:
+    """Build an FOMC rate-decision event for ``event_date``."""
+    return RateEvent(
+        event_date=event_date,
+        central_bank="FOMC",
+        region="US",
+        currency="USD",
+        description="FOMC interest rate decision",
+    )
+
+
+# FOMC rate-decision dates (announcement / second day of each two-day meeting).
+# Source: federalreserve.gov FOMC calendars. Keep sorted ascending.
+RATE_EVENTS: tuple[RateEvent, ...] = (
+    # 2025
+    _fomc(date(2025, 1, 29)),
+    _fomc(date(2025, 3, 19)),
+    _fomc(date(2025, 5, 7)),
+    _fomc(date(2025, 6, 18)),
+    _fomc(date(2025, 7, 30)),
+    _fomc(date(2025, 9, 17)),
+    _fomc(date(2025, 10, 29)),
+    _fomc(date(2025, 12, 10)),
+    # 2026
+    _fomc(date(2026, 1, 28)),
+    _fomc(date(2026, 3, 18)),
+    _fomc(date(2026, 4, 29)),
+    _fomc(date(2026, 6, 17)),
+    _fomc(date(2026, 7, 29)),
+    _fomc(date(2026, 9, 16)),
+    _fomc(date(2026, 10, 28)),
+    _fomc(date(2026, 12, 9)),
+    # 2027
+    _fomc(date(2027, 1, 27)),
+    _fomc(date(2027, 3, 17)),
+    _fomc(date(2027, 4, 28)),
+    _fomc(date(2027, 6, 9)),
+    _fomc(date(2027, 7, 28)),
+    _fomc(date(2027, 9, 15)),
+    _fomc(date(2027, 10, 27)),
+    _fomc(date(2027, 12, 8)),
+)
+
+
+def build_rate_events(
+    current_date: date,
+    days_ahead: int,
+    soon_threshold_days: int,
+    calendar: tuple[RateEvent, ...] = RATE_EVENTS,
+) -> list[dict[str, Any]]:
+    """Build global rate-event records falling within the monitoring horizon.
+
+    Pure transformation over the curated :data:`RATE_EVENTS` calendar. Only
+    events in ``[current_date, current_date + days_ahead]`` are returned, each
+    as a *global* record (``symbol: None``) so it is reported once rather than
+    per held symbol.
+
+    Args:
+        current_date: Reference "today".
+        days_ahead: Inclusive monitoring horizon in days.
+        soon_threshold_days: Events within this many days are flagged
+            ``EVENT_SOON``.
+        calendar: Curated event source (overridable for testing).
+
+    Returns:
+        List of rate-event records sorted soonest-first. Each record has
+        ``symbol`` (``None``), ``event_type`` (``"rate"``), ``event_date``
+        (ISO string), ``days_until``, ``flag`` (``"EVENT_SOON"`` or ``None``),
+        and macro metadata (``central_bank``, ``region``, ``currency``,
+        ``description``).
+    """
+    records: list[dict[str, Any]] = []
+    for event in calendar:
+        days_until = (event.event_date - current_date).days
+        if not 0 <= days_until <= days_ahead:
+            continue
+        records.append(
+            {
+                "symbol": None,
+                "event_type": RATE_EVENT_TYPE,
+                "event_date": event.event_date.isoformat(),
+                "days_until": days_until,
+                "flag": EVENT_SOON_FLAG if days_until <= soon_threshold_days else None,
+                "central_bank": event.central_bank,
+                "region": event.region,
+                "currency": event.currency,
+                "description": event.description,
+            }
+        )
+    records.sort(key=lambda record: record["days_until"])
+    return records

--- a/tests/mcp/test_events_monitor.py
+++ b/tests/mcp/test_events_monitor.py
@@ -217,6 +217,72 @@ async def test_get_upcoming_events_reports_invalid_symbols(
 
 
 @pytest.mark.asyncio
+async def test_get_upcoming_events_includes_global_rate_events(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any]], None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Global macro rate events are merged in once with symbol=None."""
+    import ib_sec_mcp.mcp.tools.events_monitor as module
+
+    rate_record = {
+        "symbol": None,
+        "event_type": "rate",
+        "event_date": "2026-01-02",
+        "days_until": 1,
+        "flag": "EVENT_SOON",
+        "central_bank": "FOMC",
+        "region": "US",
+        "currency": "USD",
+        "description": "FOMC interest rate decision",
+    }
+    monkeypatch.setattr(module, "build_rate_events", lambda *a, **k: [rate_record])
+    patch_ticker({"AAPL": {"Earnings Date": [date(2026, 1, 10)], "Ex-Dividend Date": None}})
+
+    result = await call_tool_fn(
+        test_mcp, "get_upcoming_events", days=14, symbols=["AAPL"], ctx=None
+    )
+    data = json.loads(result)
+
+    rate_events = [e for e in data["events"] if e["event_type"] == "rate"]
+    assert len(rate_events) == 1
+    assert rate_events[0]["symbol"] is None
+    assert rate_events[0]["central_bank"] == "FOMC"
+    # Soonest-first ordering puts the imminent rate event ahead of the earnings.
+    assert data["events"][0]["event_type"] == "rate"
+    assert data["event_soon_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_events_can_exclude_rate_events(
+    test_mcp: FastMCP,
+    patch_ticker: Callable[[dict[str, Any]], None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include_rate_events=False suppresses the macro rate feed."""
+    import ib_sec_mcp.mcp.tools.events_monitor as module
+
+    monkeypatch.setattr(
+        module,
+        "build_rate_events",
+        lambda *a, **k: [{"symbol": None, "event_type": "rate", "days_until": 1, "flag": None}],
+    )
+    patch_ticker({"AAPL": {"Earnings Date": [date(2026, 1, 10)], "Ex-Dividend Date": None}})
+
+    result = await call_tool_fn(
+        test_mcp,
+        "get_upcoming_events",
+        days=14,
+        symbols=["AAPL"],
+        include_rate_events=False,
+        ctx=None,
+    )
+    data = json.loads(result)
+
+    assert all(e["event_type"] != "rate" for e in data["events"])
+
+
+@pytest.mark.asyncio
 async def test_get_upcoming_events_rejects_negative_days(test_mcp: FastMCP) -> None:
     """A negative horizon is rejected before any yfinance access."""
     result = await call_tool_fn(test_mcp, "get_upcoming_events", days=-1, ctx=None)

--- a/tests/mcp/test_position_advisor.py
+++ b/tests/mcp/test_position_advisor.py
@@ -523,3 +523,84 @@ class TestEventRisk:
         )
         assert data["event_risk"]["near_term"] is False
         assert data["event_risk"]["events"]  # still surfaced for visibility
+
+    async def test_imminent_rate_event_flags_near_term_with_label(
+        self, test_mcp: FastMCP, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An imminent macro rate decision drives near-term risk and a labelled note."""
+        patch_components(
+            monkeypatch,
+            tech=make_tech(score=0.6, current_level="neutral", rsi_signal="neutral"),
+            stock_ctx=make_stock_ctx(),
+            sentiment=make_sentiment("0.5"),
+            events=[
+                {
+                    "symbol": None,
+                    "event_type": "rate",
+                    "event_date": "2026-01-03",
+                    "days_until": 2,
+                    "flag": "EVENT_SOON",
+                    "central_bank": "FOMC",
+                    "region": "US",
+                    "currency": "USD",
+                    "description": "FOMC interest rate decision",
+                }
+            ],
+        )
+        data = json.loads(
+            await call_tool_fn(test_mcp, "evaluate_position", symbol="AAPL", ctx=None)
+        )
+        assert data["event_risk"]["near_term"] is True
+        assert data["event_risk"]["next_earnings_days"] is None
+        assert any("FOMC interest rate decision" in r for r in data["rationale"])
+
+    async def test_fetch_event_risk_merges_global_rate_events(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_fetch_event_risk appends curated rate events to per-symbol events."""
+        rate_record = {
+            "symbol": None,
+            "event_type": "rate",
+            "event_date": "2026-01-02",
+            "days_until": 1,
+            "flag": "EVENT_SOON",
+            "central_bank": "FOMC",
+            "region": "US",
+            "currency": "USD",
+            "description": "FOMC interest rate decision",
+        }
+        monkeypatch.setattr(pa, "build_rate_events", lambda *a, **k: [rate_record])
+
+        class _Ticker:
+            def __init__(self, symbol: str) -> None:
+                self.symbol = symbol
+
+            @property
+            def calendar(self) -> dict:
+                return {"Earnings Date": [], "Ex-Dividend Date": None}
+
+        with patch("yfinance.Ticker", _Ticker):
+            events = await pa._fetch_event_risk("AAPL")
+
+        assert rate_record in events
+        assert any(e["event_type"] == "rate" for e in events)
+
+    async def test_fetch_event_risk_keeps_rate_events_on_yfinance_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A yfinance failure still yields the offline rate events."""
+        rate_record = {"symbol": None, "event_type": "rate", "days_until": 1, "flag": "EVENT_SOON"}
+        monkeypatch.setattr(pa, "build_rate_events", lambda *a, **k: [rate_record])
+
+        class _Ticker:
+            def __init__(self, symbol: str) -> None:
+                pass
+
+            @property
+            def calendar(self) -> dict:
+                raise RuntimeError("yfinance down")
+
+        with patch("yfinance.Ticker", _Ticker):
+            events = await pa._fetch_event_risk("AAPL")
+
+        assert events == [rate_record]

--- a/tests/mcp/test_position_advisor.py
+++ b/tests/mcp/test_position_advisor.py
@@ -604,3 +604,35 @@ class TestEventRisk:
             events = await pa._fetch_event_risk("AAPL")
 
         assert events == [rate_record]
+
+
+class TestEventRiskHelpers:
+    """Unit tests for the pure event-risk helpers (PR #153 review fixes)."""
+
+    def test_format_event_note_tolerates_missing_event_type(self) -> None:
+        """A record without event_type does not raise KeyError."""
+        note = pa._format_event_note({"days_until": 2, "event_date": "2026-01-03"})
+        assert "in 2 day(s) on 2026-01-03" in note
+
+    def test_format_event_note_rate_uses_description(self) -> None:
+        note = pa._format_event_note(
+            {
+                "event_type": "rate",
+                "days_until": 1,
+                "event_date": "2026-01-02",
+                "description": "FOMC interest rate decision",
+            }
+        )
+        assert note == "FOMC interest rate decision in 1 day(s) on 2026-01-02"
+
+    def test_summarize_event_risk_sorts_combined_events(self) -> None:
+        """Combined per-symbol + rate events are returned chronologically."""
+        events = [
+            {"symbol": "AAPL", "event_type": "ex_dividend", "days_until": 9, "flag": None},
+            {"symbol": None, "event_type": "rate", "days_until": 2, "flag": "EVENT_SOON"},
+            {"symbol": "AAPL", "event_type": "earnings", "days_until": 5, "flag": None},
+        ]
+        summary = pa._summarize_event_risk(events)
+        assert [e["days_until"] for e in summary["events"]] == [2, 5, 9]
+        # next_earnings_days resolves to the nearest earnings event.
+        assert summary["next_earnings_days"] == 5

--- a/tests/mcp/test_rate_calendar.py
+++ b/tests/mcp/test_rate_calendar.py
@@ -1,0 +1,71 @@
+"""Tests for the curated macro interest-rate event calendar."""
+
+from datetime import date
+
+from ib_sec_mcp.mcp.tools.rate_calendar import (
+    RATE_EVENTS,
+    RateEvent,
+    build_rate_events,
+)
+
+# A small, deterministic calendar used for horizon/flag assertions.
+SAMPLE_CALENDAR: tuple[RateEvent, ...] = (
+    RateEvent(date(2026, 1, 3), "FOMC", "US", "USD", "FOMC interest rate decision"),
+    RateEvent(date(2026, 1, 10), "FOMC", "US", "USD", "FOMC interest rate decision"),
+    RateEvent(date(2026, 2, 1), "FOMC", "US", "USD", "FOMC interest rate decision"),
+)
+
+
+def test_build_rate_events_flags_and_filters() -> None:
+    """Imminent events are flagged EVENT_SOON; out-of-horizon events dropped."""
+    records = build_rate_events(date(2026, 1, 1), 14, 3, calendar=SAMPLE_CALENDAR)
+
+    # 2026-02-01 (31 days) is beyond the 14-day horizon and excluded.
+    assert [r["event_date"] for r in records] == ["2026-01-03", "2026-01-10"]
+
+    by_date = {r["event_date"]: r for r in records}
+    assert by_date["2026-01-03"]["days_until"] == 2
+    assert by_date["2026-01-03"]["flag"] == "EVENT_SOON"  # within 3 days
+    assert by_date["2026-01-10"]["days_until"] == 9
+    assert by_date["2026-01-10"]["flag"] is None
+
+
+def test_build_rate_events_are_global_with_metadata() -> None:
+    """Rate events carry symbol=None plus macro metadata."""
+    records = build_rate_events(date(2026, 1, 1), 14, 3, calendar=SAMPLE_CALENDAR)
+
+    record = records[0]
+    assert record["symbol"] is None
+    assert record["event_type"] == "rate"
+    assert record["central_bank"] == "FOMC"
+    assert record["region"] == "US"
+    assert record["currency"] == "USD"
+    assert record["description"] == "FOMC interest rate decision"
+
+
+def test_build_rate_events_sorted_soonest_first() -> None:
+    """Records are returned sorted by days_until ascending."""
+    unsorted_calendar = (SAMPLE_CALENDAR[1], SAMPLE_CALENDAR[0])
+    records = build_rate_events(date(2026, 1, 1), 14, 3, calendar=unsorted_calendar)
+    assert [r["days_until"] for r in records] == [2, 9]
+
+
+def test_build_rate_events_empty_when_none_in_window() -> None:
+    """No events within the horizon yields an empty list (not an error)."""
+    assert build_rate_events(date(2026, 1, 1), 1, 3, calendar=SAMPLE_CALENDAR) == []
+
+
+def test_build_rate_events_includes_today() -> None:
+    """An event landing exactly today is in-horizon and flagged EVENT_SOON."""
+    calendar = (RateEvent(date(2026, 1, 1), "FOMC", "US", "USD", "FOMC interest rate decision"),)
+    records = build_rate_events(date(2026, 1, 1), 14, 3, calendar=calendar)
+    assert records[0]["days_until"] == 0
+    assert records[0]["flag"] == "EVENT_SOON"
+
+
+def test_curated_fomc_calendar_is_sorted_and_well_formed() -> None:
+    """The shipped FOMC calendar is ascending and uses the rate schema."""
+    dates = [event.event_date for event in RATE_EVENTS]
+    assert dates == sorted(dates)
+    assert all(event.central_bank == "FOMC" for event in RATE_EVENTS)
+    assert all(event.currency == "USD" for event in RATE_EVENTS)


### PR DESCRIPTION
## Summary

Resolves #152 (follow-up from #131 / #151). `get_upcoming_events` previously sourced only **earnings** and **ex-dividend** events per symbol from yfinance. Interest-rate (macro) events were deferred because there is no per-symbol macro source. This PR adds them via a **curated, offline FOMC calendar** — the Fed publishes decision dates a year+ in advance, so a static calendar is the reliable, deterministic, network-free data source.

## Design decisions

- **Global, not per-symbol.** A rate decision moves all risk assets, so each event is emitted **once** with `symbol: null` rather than duplicated per ticker. Records carry `central_bank` / `region` / `currency` metadata so consumers can filter by currency/asset class if desired.
- **Same record shape** as corporate events (`event_type`, `event_date`, `days_until`, `flag`) so they merge cleanly into `get_upcoming_events`, `evaluate_position` event risk, and `/daily-check` `EVENT_SOON` alerts — reusing the existing plumbing unchanged.
- **Extensible**: only FOMC is curated today, but `RateEvent` / `RATE_EVENTS` are open for ECB/BoE/BoJ without touching the builder.

## Changes

- **New** `ib_sec_mcp/mcp/tools/rate_calendar.py`: curated FOMC announcement dates (2025–2027, sourced from federalreserve.gov) + `build_rate_events()` pure builder emitting `event_type="rate"` records.
- `get_upcoming_events`: new `include_rate_events: bool = True` param; global rate events merged once; docstring updated (`event_type` now includes `"rate"`).
- `evaluate_position` (`position_advisor.py`): `_fetch_event_risk` merges curated rate events with per-symbol events (rate events retained even if yfinance fails); friendlier rate-event notes in the rationale.
- `/daily-check`: documents rate events in Step 4.5 + alert table.

## Testing

- **New** `tests/mcp/test_rate_calendar.py` — horizon filtering, `EVENT_SOON` flag, global `symbol=None` + metadata, sorting, curated-calendar integrity.
- Extended `test_events_monitor.py` (inclusion + opt-out) and `test_position_advisor.py` (rate rationale, merge, graceful degradation on yfinance failure).
- Full suite: **1239 passed**, coverage 78.87% (gate 48%). `rate_calendar.py` at 100%. `ruff` + `mypy` clean.

## Acceptance criteria (issue #152)

- [x] Source macro interest-rate events from a calendar feed (curated FOMC calendar)
- [x] Emit them as `event_type: "rate"` records in `get_upcoming_events`
- [x] Decide global vs currency/asset-class filtered → **global**, with currency metadata for optional downstream filtering
- [x] Feed into `/daily-check` `EVENT_SOON` alerts and `evaluate_position` event risk consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)